### PR TITLE
Refactor pipeline tests to DRY up CDKPipelineDeploy tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,4 +5,5 @@ module.exports = {
     '^.+\\.tsx?$': 'ts-jest',
   },
   clearMocks: true,
+  resetModules: true,
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6216,6 +6216,12 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "givens": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/givens/-/givens-1.3.5.tgz",
+      "integrity": "sha512-12Om1LvrgM4Fm6XETP0UVWGgDN/6W4D5Hz30pgauYVTH4J4ht+bOvuzyx/XYWj3FJ8tM+Rug0c6Gat0NBJmN2Q==",
+      "dev": true
+    },
     "glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
-    "test": "npm run lint && jest",
+    "test": "jest",
     "cdk": "cdk",
     "lint": "standardx '**/*.ts'",
     "format": "standardx --fix '**/*.ts'"
@@ -23,6 +23,7 @@
     "@typescript-eslint/parser": "^4.9.0",
     "aws-cdk": "^1.75.0",
     "eslint-plugin-jest": "^24.1.3",
+    "givens": "^1.3.5",
     "jest": "^26.6.3",
     "standard": "^16.0.3",
     "standardx": "^7.0.0",

--- a/src/cdk-pipeline-deploy.ts
+++ b/src/cdk-pipeline-deploy.ts
@@ -10,6 +10,7 @@ export interface ICDKPipelineDeployProps extends PipelineProjectProps {
    * permissions to create change sets on these stacks.
    */
   readonly targetStack: string;
+
   /**
    * The stack names that the target stack will depend on. Will add permissions
    * to also create change sets on these stacks. Note: This can be ignored

--- a/test/buzz-pipeline.test.ts
+++ b/test/buzz-pipeline.test.ts
@@ -1,58 +1,69 @@
-import { expect as expectCDK, haveResource, haveResourceLike } from '@aws-cdk/assert'
+import { expect as expectCDK, objectLike, haveResourceLike, arrayWith, stringLike } from '@aws-cdk/assert'
 import * as cdk from '@aws-cdk/core'
-import { BuzzPipelineStack } from '../src/buzz/buzz-pipeline'
+import { BuzzPipelineStack, CDPipelineStackProps } from '../src/buzz/buzz-pipeline'
 import { getContextByNamespace } from '../src/context-helpers'
 import { FoundationStack } from '../src/foundation-stack'
+import { mocked } from 'ts-jest/utils'
+import getGiven from 'givens'
 import helpers = require('../test/helpers')
+import { CustomEnvironment } from '../src/custom-environment'
 
-describe('CodeBuild actions', () => {
-  beforeEach(() => {
-    helpers.mockDockerCredentials()
+// A set of variables that won't get set until used
+interface lazyEvals {
+  env: CustomEnvironment
+  app: cdk.App
+  foundationStack: FoundationStack
+  subject: BuzzPipelineStack
+  pipelineProps: CDPipelineStackProps
+}
+const lazyEval = getGiven<lazyEvals>()
+
+describe('BuzzPipeline', () => {
+  process.env.CDK_CONTEXT_JSON = JSON.stringify({
+    dockerhubCredentialsPath: 'test.context.dockerhubCredentialsPath',
   })
-  const stack = () => {
-    process.env.CDK_CONTEXT_JSON = JSON.stringify({ dockerhubCredentialsPath: '/path/to/oauth' })
-    const app = new cdk.App()
-    // WHEN
-    const env = {
-      name: 'test',
-      domainName: 'test.edu',
-      domainStackName: 'test-edu-domain',
-      networkStackName: 'test-network',
-      region: 'test-region',
-      account: 'test-account',
-      createDns: true,
-      useVpcId: '123456',
-      slackNotifyStackName: 'slack-test',
-      createGithubWebhooks: false,
-      useExistingDnsZone: false,
-      notificationReceivers: 'test@test.edu',
-      alarmsEmail: 'test@test.edu',
-    }
-    const hostnamePrefix = 'buzz-test'
-    const buzzContext = getContextByNamespace('buzz')
-    const foundationStack = new FoundationStack(app, 'MyFoundationStack', { env })
 
-    return new BuzzPipelineStack(app, 'MyBuzzPipelineStack', {
-      env,
-      foundationStack,
-      hostnamePrefix,
-      ...buzzContext,
-      namespace: 'testNamespace',
-      oauthTokenPath: '/path/to/oauth',
-      ssmPrefix: 'ssmPrefix',
-      appSourceArtifact: 'testAppArtifact',
-      migrateSecurityGroup: 'sg-123456',
-    })
-  }
-  // Check for Desired resources with proper configurations
+  lazyEval('env', () => ({
+    name: 'test.env.name',
+    domainName: 'test.env.domainName',
+    domainStackName: 'test.env.domainStackName',
+    networkStackName: 'test.env.networkStackName',
+    region: 'test.env.region',
+    account: 'test.env.account',
+    createDns: true,
+    useVpcId: 'test.env.useVpcId',
+    slackNotifyStackName: 'test.env.slackNotifyStackName',
+    createGithubWebhooks: false,
+    useExistingDnsZone: false,
+    notificationReceivers: 'test.env.notificationReceivers',
+    alarmsEmail: 'test.env.alarmsEmail',
+  }))
+  lazyEval('app', () => new cdk.App())
+  lazyEval('foundationStack', () => new FoundationStack(lazyEval.app, 'MyFoundationStack', { env: lazyEval.env }))
+  lazyEval('pipelineProps', () => ({
+    env: lazyEval.env,
+    appRepoOwner: 'test.pipelineProp.appRepoOwner',
+    appRepoName: 'test.pipelineProp.appRepoName',
+    appSourceBranch: 'test.pipelineProp.appSourceBranch',
+    infraRepoOwner: 'test.pipelineProp.infraRepoOwner',
+    infraRepoName: 'test.pipelineProp.infraRepoName',
+    infraSourceBranch: 'test.pipelineProp.infraSourceBranch',
+    foundationStack: lazyEval.foundationStack,
+    namespace: 'test.pipelineProp.namespace',
+    oauthTokenPath: 'test.pipelineProp.oauthTokenPath',
+    dockerhubCredentialsPath: 'test.pipelineProp.dockerhubCredentialsPath',
+    hostnamePrefix: 'test.pipelineProp.hostnamePrefix',
+    owner: 'test.pipelineProp.owner',
+    contact: 'test.pipelineProp.contact',
+  }))
+  lazyEval('subject', () => new BuzzPipelineStack(lazyEval.app, 'MyBuzzPipelineStack', lazyEval.pipelineProps))
 
   test('creates codebuilds for test DB migration', () => {
-    const newStack = stack()
-    expectCDK(newStack).to(haveResourceLike('AWS::CodeBuild::Project', {
+    expectCDK(lazyEval.subject).to(haveResourceLike('AWS::CodeBuild::Project', {
       Environment: {
         Image: 'ruby:2.4.4', // this should match what is in the helper class - and only the migrate tasks use the base ruby without app code
         RegistryCredential: {
-          Credential: 'test-secret',
+          Credential: 'test.pipelineProp.dockerhubCredentialsPath',
           CredentialProvider: 'SECRETS_MANAGER',
         },
       },
@@ -60,7 +71,7 @@ describe('CodeBuild actions', () => {
         SecurityGroupIds: [
           {
             'Fn::GetAtt': [
-              'testNamespaceMigrateTestMigrateSecurityGroup8805104E',
+              'testpipelinePropnamespaceMigrateTestMigrateSecurityGroup762A6562',
               'GroupId',
             ],
           },
@@ -72,12 +83,11 @@ describe('CodeBuild actions', () => {
   })
 
   test('creates codebuilds for prod DB migration', () => {
-    const newStack = stack()
-    expectCDK(newStack).to(haveResourceLike('AWS::CodeBuild::Project', {
+    expectCDK(lazyEval.subject).to(haveResourceLike('AWS::CodeBuild::Project', {
       Environment: {
         Image: 'ruby:2.4.4', // this should match what is in the helper class - and only the migrate tasks use the base ruby without app code
         RegistryCredential: {
-          Credential: 'test-secret',
+          Credential: 'test.pipelineProp.dockerhubCredentialsPath',
           CredentialProvider: 'SECRETS_MANAGER',
         },
       },
@@ -85,7 +95,7 @@ describe('CodeBuild actions', () => {
         SecurityGroupIds: [
           {
             'Fn::GetAtt': [
-              'testNamespaceMigrateProdMigrateSecurityGroup2984AD20',
+              'testpipelinePropnamespaceMigrateProdMigrateSecurityGroup34D46097',
               'GroupId',
             ],
           },
@@ -96,277 +106,167 @@ describe('CodeBuild actions', () => {
     ))
   })
 
-  test('creates smoke test runner', () => {
-    const newStack = stack()
-    expectCDK(newStack).to(haveResourceLike('AWS::CodeBuild::Project', {
+  test('test stage runs smoke tests that make requests to the test host', () => {
+    expectCDK(lazyEval.subject).to(haveResourceLike('AWS::CodeBuild::Project', {
+      Source: {
+        BuildSpec: {
+          'Fn::Join': [
+            '',
+            [
+              // stringLike's wildcard doesn't seem to consume \n characters, so this is a bit more explicit of a match than I'd like
+              stringLike('{\n*"phases": {\n*"build": {\n*"commands": [\n*"newman run * --env-var app-host=test.pipelineProp.hostnamePrefix-test.'),
+              {
+                'Fn::ImportValue': 'test.env.domainStackName:DomainName',
+              },
+              stringLike('*--env-var host-protocol=https"\n*]\n*}\n*},\n*\n}'),
+            ],
+          ],
+        },
+      },
+    }))
+  })
+
+  test('smoke tests uses the newman image and gets dockerhub credentials from context', () => {
+    expectCDK(lazyEval.subject).to(haveResourceLike('AWS::CodeBuild::Project', {
       Environment: {
         Image: 'postman/newman:5',
         RegistryCredential: {
-          Credential: 'test-secret',
+          Credential: 'test.context.dockerhubCredentialsPath',
           CredentialProvider: 'SECRETS_MANAGER',
         },
       },
     }))
   })
 
-  test('creates codebuild for test buzz deployment', () => {
-    const newStack = stack()
-    expectCDK(newStack).to(haveResourceLike('AWS::CodeBuild::Project', {
-      Artifacts: {
-        Type: 'CODEPIPELINE',
-      },
-      Environment: {
-        Image: 'aws/codebuild/standard:4.0',
-      },
-      Source: {
-        BuildSpec: '{\n  "artifacts": {\n    "files": []\n  },\n  "phases": {\n    "install": {\n      "commands": [\n        "cd $CODEBUILD_SRC_DIR/",\n        "npm install"\n      ],\n      "runtime-versions": {\n        "nodejs": "12.x"\n      }\n    },\n    "pre_build": {\n      "commands": [\n        "cd $CODEBUILD_SRC_DIR_AppCode"\n      ]\n    },\n    "build": {\n      "commands": [\n        "cd $CODEBUILD_SRC_DIR/",\n        "echo $DOCKER_TOKEN | docker login --username $DOCKER_USERNAME --password-stdin",\n        "npm run cdk deploy -- testNamespace-test-buzz                 --require-approval never --exclusively                 -c \\"namespace=testNamespace-test\\" -c \\"env=test\\"  -c \\"owner=undefined\\" -c \\"contact=undefined\\" -c \\"networkStack=test-network\\" -c \\"domainStack=test-edu-domain\\" -c \\"createDns=true\\" -c \\"buzz:hostnamePrefix=buzz-test\\" -c \\"buzz:appDirectory=$CODEBUILD_SRC_DIR_AppCode\\" -c \\"infraDirectory=$CODEBUILD_SRC_DIR\\""\n      ]\n    },\n    "post_build": {\n      "commands": []\n    }\n  },\n  "version": "0.2"\n}',
-        Type: 'CODEPIPELINE',
-      },
-    }))
+  test('calls the CDKPipelineProject with the correct properties to create the test deployment', async () => {
+    // Mock the pipeine deploy then reimport its dependencies
+    jest.doMock('../src/cdk-pipeline-deploy')
+    const CDKPipelineDeploy = (await import('../src/cdk-pipeline-deploy')).CDKPipelineDeploy
+    const BuzzPipelineStack = (await import('../src/buzz/buzz-pipeline')).BuzzPipelineStack
+    const MockedCDKPipelineDeploy = mocked(CDKPipelineDeploy, true)
+    MockedCDKPipelineDeploy.mockImplementation(helpers.mockCDKPipelineDeploy)
+
+    // Must instantiate the stack in this scope or the mock won't work
+    const subject = new BuzzPipelineStack(lazyEval.app, 'MyBuzzPipelineStack', lazyEval.pipelineProps)
+
+    // A lot of this should be separated out into different expectations/tests, but manual mocking
+    // of the local module is pretty painful, so doing this all in one shot. Adding some comments
+    // to call out some of the expectations
+    expect(MockedCDKPipelineDeploy).toHaveBeenCalledWith(
+      expect.any(Object),
+      'test.pipelineProp.namespace-DeployTest', // Creates a CodeBuild project with an id of namespace-DeployTest
+      expect.objectContaining({
+        namespace: 'test.pipelineProp.namespace-test', // Adds -test to the provided namespace
+        targetStack: 'test.pipelineProp.namespace-test-buzz', // Targets the test stack
+        contextEnvName: 'test.env.name',
+        dockerhubCredentialsPath: 'test.pipelineProp.dockerhubCredentialsPath',
+        additionalContext: {
+          'buzz:appDirectory': '$CODEBUILD_SRC_DIR_AppCode',
+          'buzz:hostnamePrefix': 'test.pipelineProp.hostnamePrefix-test', // Adds -test to the provided hostname
+          createDns: 'true',
+          domainStack: 'test.env.domainStackName',
+          infraDirectory: '$CODEBUILD_SRC_DIR',
+          networkStack: 'test.env.networkStackName',
+          owner: 'test.pipelineProp.owner',
+          contact: 'test.pipelineProp.contact',
+        },
+      }),
+    )
   })
 
-  test('creates codebuild for prod buzz deployment', () => {
-    const newStack = stack()
-    expectCDK(newStack).to(haveResourceLike('AWS::CodeBuild::Project', {
-      Artifacts: {
-        Type: 'CODEPIPELINE',
-      },
-      Environment: {
-        Image: 'aws/codebuild/standard:4.0',
-      },
-      Source: {
-        BuildSpec: '{\n  "artifacts": {\n    "files": []\n  },\n  "phases": {\n    "install": {\n      "commands": [\n        "cd $CODEBUILD_SRC_DIR/",\n        "npm install"\n      ],\n      "runtime-versions": {\n        "nodejs": "12.x"\n      }\n    },\n    "pre_build": {\n      "commands": [\n        "cd $CODEBUILD_SRC_DIR_AppCode"\n      ]\n    },\n    "build": {\n      "commands": [\n        "cd $CODEBUILD_SRC_DIR/",\n        "echo $DOCKER_TOKEN | docker login --username $DOCKER_USERNAME --password-stdin",\n        "npm run cdk deploy -- testNamespace-prod-buzz                 --require-approval never --exclusively                 -c \\"namespace=testNamespace-prod\\" -c \\"env=test\\"  -c \\"owner=undefined\\" -c \\"contact=undefined\\" -c \\"networkStack=undefined\\" -c \\"domainStack=undefined\\" -c \\"createDns=false\\" -c \\"buzz:hostnamePrefix=buzz\\" -c \\"buzz:appDirectory=$CODEBUILD_SRC_DIR_AppCode\\" -c \\"infraDirectory=$CODEBUILD_SRC_DIR\\""\n      ]\n    },\n    "post_build": {\n      "commands": []\n    }\n  },\n  "version": "0.2"\n}',
-        Type: 'CODEPIPELINE',
-      },
-    }))
-  })
-})
+  test('calls the CDKPipelineProject with the correct properties to create the prod deployment', async () => {
+    // Mock the pipeine deploy then reimport its dependencies
+    jest.doMock('../src/cdk-pipeline-deploy')
+    const CDKPipelineDeploy = (await import('../src/cdk-pipeline-deploy')).CDKPipelineDeploy
+    const BuzzPipelineStack = (await import('../src/buzz/buzz-pipeline')).BuzzPipelineStack
+    const MockedCDKPipelineDeploy = mocked(CDKPipelineDeploy, true)
+    MockedCDKPipelineDeploy.mockImplementation(helpers.mockCDKPipelineDeploy)
 
-describe('CodePipeline', () => {
-  beforeEach(() => {
-    helpers.mockDockerCredentials()
-  })
-  const stack = () => {
-    const app = new cdk.App()
-    // WHEN
-    const env = {
-      name: 'test',
-      domainName: 'test.edu',
-      domainStackName: 'test-edu-domain',
-      networkStackName: 'test-network',
-      region: 'test-region',
-      account: 'test-account',
-      createDns: true,
-      useVpcId: '123456',
-      slackNotifyStackName: 'slack-test',
-      createGithubWebhooks: false,
-      useExistingDnsZone: false,
-      notificationReceivers: 'test@test.edu',
-      alarmsEmail: 'test@test.edu',
-    }
-    const hostnamePrefix = 'buzz-test'
-    const buzzContext = getContextByNamespace('buzz')
-    const foundationStack = new FoundationStack(app, 'MyFoundationStack', { env })
+    // Must instantiate the stack in this scope or the mock won't work
+    const subject = new BuzzPipelineStack(lazyEval.app, 'MyBuzzPipelineStack', lazyEval.pipelineProps)
 
-    return new BuzzPipelineStack(app, 'MyBuzzPipelineStack', {
-      env,
-      foundationStack,
-      hostnamePrefix,
-      ...buzzContext,
-      namespace: 'testNamespace',
-      oauthTokenPath: '/path/to/oauth',
-      ssmPrefix: 'ssmPrefix',
-      appSourceArtifact: 'testAppArtifact',
-      migrateSecurityGroup: 'sg-123456',
-      dockerhubCredentialsPath: '/path/to/credentials',
-    })
-  }
-  test('creates a CodePipeline with Source, Test, and Production stages', () => {
-    const newStack = stack()
-    expectCDK(newStack).to(haveResourceLike('AWS::CodePipeline::Pipeline', {
+    // A lot of this should be separated out into different expectations/tests, but manual mocking
+    // of the local module is pretty painful, so doing this all in one shot. Adding some comments
+    // to call out some of the expectations
+    expect(MockedCDKPipelineDeploy).toHaveBeenCalledWith(
+      expect.any(Object),
+      'test.pipelineProp.namespace-DeployProd', // Creates a CodeBuild project with an id of namespace-DeployProd
+      expect.objectContaining({
+        namespace: 'test.pipelineProp.namespace-prod', // Adds -prod to the provided namespace
+        targetStack: 'test.pipelineProp.namespace-prod-buzz', // Targets the prod stack
+        contextEnvName: 'test.env.name',
+        dockerhubCredentialsPath: 'test.pipelineProp.dockerhubCredentialsPath',
+        additionalContext: {
+          'buzz:appDirectory': '$CODEBUILD_SRC_DIR_AppCode',
+          'buzz:hostnamePrefix': 'test.pipelineProp.hostnamePrefix', // Uses the provided hostname without modification
+          createDns: 'true',
+          domainStack: 'test.env.domainStackName',
+          infraDirectory: '$CODEBUILD_SRC_DIR',
+          networkStack: 'test.env.networkStackName',
+          owner: 'test.pipelineProp.owner',
+          contact: 'test.pipelineProp.contact',
+        },
+      }),
+    )
+  })
+
+  test('creates a CodePipeline with stages in the following order: Source->Test->Production', () => {
+    expectCDK(lazyEval.subject).to(haveResourceLike('AWS::CodePipeline::Pipeline', objectLike({
       Stages: [
-        {
-          Actions: [
-            {
-              ActionTypeId: {
-                Category: 'Source',
-              },
-            },
-            {
-              ActionTypeId: {
-                Category: 'Source',
-              },
-            },
-          ],
+        objectLike({
           Name: 'Source',
-        },
-        {
-          Actions: [
-            {
-              ActionTypeId: {
-                Category: 'Build',
-              },
-            },
-            {
-              ActionTypeId: {
-                Category: 'Build',
-              },
-            },
-            {
-              ActionTypeId: {
-                Category: 'Build',
-              },
-            },
-          ],
+        }),
+        objectLike({
           Name: 'Test',
-        },
-        {
-          Actions: [
-            {
-              ActionTypeId: {
-                Category: 'Build',
-              },
-            },
-            {
-              ActionTypeId: {
-                Category: 'Build',
-              },
-            },
-          ],
+        }),
+        objectLike({
           Name: 'Production',
-        },
+        }),
       ],
+    })))
+  })
+
+  test('test stage runs actions in the following order: db migration->deploy->smoke tests->approval', () => {
+    expectCDK(lazyEval.subject).to(haveResourceLike('AWS::CodePipeline::Pipeline', {
+      Stages: arrayWith(objectLike({
+        Name: 'Test',
+        Actions: [
+          objectLike({
+            Name: 'DBMigrate',
+            RunOrder: 1,
+          }),
+          objectLike({
+            Name: 'Deploy',
+            RunOrder: 2,
+          }),
+          objectLike({
+            Name: 'SmokeTests',
+            RunOrder: 98,
+          }),
+          objectLike({
+            Name: 'Approval',
+            RunOrder: 99,
+          }),
+        ],
+      })),
     }))
   })
 
-  test('pipeline runs smoke tests after everything but approval', () => {
-    const newStack = stack()
-    expectCDK(newStack).to(haveResourceLike('AWS::CodePipeline::Pipeline', {
-      Stages: [
-        {
-          Actions: [
-            {
-              ActionTypeId: {
-                Category: 'Source',
-              },
-            },
-            {
-              ActionTypeId: {
-                Category: 'Source',
-              },
-            },
-          ],
-          Name: 'Source',
-        },
-        {
-          Actions: [
-            {
-              ActionTypeId: {
-                Category: 'Build',
-                Owner: 'AWS',
-              },
-            },
-            {
-              ActionTypeId: {
-                Category: 'Build',
-                Owner: 'AWS',
-              },
-            },
-            {
-              ActionTypeId: {
-                Category: 'Build',
-                Owner: 'AWS',
-              },
-              Name: 'SmokeTests',
-              RunOrder: 98,
-            },
-          ],
-          Name: 'Test',
-        },
-        {
-          Actions: [
-            {
-              ActionTypeId: {
-                Category: 'Build',
-              },
-            },
-            {
-              ActionTypeId: {
-                Category: 'Build',
-                Owner: 'AWS',
-              },
-            },
-          ],
-          Name: 'Production',
-        },
-      ],
-    }))
-  })
-
-  test('pipeline runs db migrates before anything else', () => {
-    const newStack = stack()
-    expectCDK(newStack).to(haveResourceLike('AWS::CodePipeline::Pipeline', {
-      Stages: [
-        {
-          Actions: [
-            {
-              ActionTypeId: {
-                Category: 'Source',
-              },
-            },
-            {
-              ActionTypeId: {
-                Category: 'Source',
-              },
-            },
-          ],
-          Name: 'Source',
-        },
-        {
-          Actions: [
-            {
-              ActionTypeId: {
-                Category: 'Build',
-                Owner: 'AWS',
-              },
-              Name: 'DBMigrate',
-              RunOrder: 1,
-            },
-            {
-              ActionTypeId: {
-                Category: 'Build',
-                Owner: 'AWS',
-              },
-            },
-            {
-              ActionTypeId: {
-                Category: 'Build',
-                Owner: 'AWS',
-              },
-            },
-          ],
-          Name: 'Test',
-        },
-        {
-          Actions: [
-            {
-              ActionTypeId: {
-                Category: 'Build',
-                Owner: 'AWS',
-              },
-              Name: 'DBMigrate',
-              RunOrder: 1,
-            },
-            {
-              ActionTypeId: {
-                Category: 'Build',
-                Owner: 'AWS',
-              },
-            },
-          ],
-          Name: 'Production',
-        },
-      ],
+  test('production stage runs actions in the following order: db migration->deploy', () => {
+    expectCDK(lazyEval.subject).to(haveResourceLike('AWS::CodePipeline::Pipeline', {
+      Stages: arrayWith(objectLike({
+        Name: 'Production',
+        Actions: [
+          objectLike({
+            Name: 'DBMigrate',
+            RunOrder: 1,
+          }),
+          objectLike({
+            Name: 'Deploy',
+            RunOrder: 2,
+          }),
+        ],
+      })),
     }))
   })
 })

--- a/test/cdk-pipeline-deploy.test.ts
+++ b/test/cdk-pipeline-deploy.test.ts
@@ -1,0 +1,26 @@
+
+describe('CDKPipelineDeploy', () => {
+  test.todo('specifies the infrastructure code as the primary input')
+  test.todo('adds the application code as extra inputs')
+  test.todo('allows overriding where to find the cdk project')
+  test.todo('runs any build scripts before staging the files and deploying')
+  test.todo('runs any given post deploy commands')
+  test.todo('outputs files correctly to a given artifact')
+  test.todo('adds additional installs to the buildspec for each kvp in additionalRuntimeEnvironments')
+  test.todo('authenticates with Dockerhub using the given path for credentials before deploying to assist with pulling for any container builds')
+  test.todo('allows completely overriding the PipelineProject props if necessary')
+
+  describe('deploy command', () => {
+    test.todo('specifies the target stack exclusively')
+    test.todo('adds the correct stack namespace override')
+    test.todo('adds the correct env override')
+    test.todo('adds any additional context overrides')
+  })
+
+  describe('gives the pipeline permission to', () => {
+    test.todo('modify the target stack')
+    test.todo('modify any dependent stacks')
+    test.todo('read logs when generating output for failed events')
+    test.todo('read CDK bootstrap stack/bucket')
+  })
+})

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,11 +1,15 @@
 import { SynthUtils } from '@aws-cdk/assert'
+import { PipelineProject } from '@aws-cdk/aws-codebuild'
+import { CodeBuildAction } from '@aws-cdk/aws-codepipeline-actions'
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import { IGrantable } from '@aws-cdk/aws-iam'
 import { HostedZone } from '@aws-cdk/aws-route53'
 import { Secret } from '@aws-cdk/aws-secretsmanager'
-import { Stack } from '@aws-cdk/core'
+import { Construct, Stack } from '@aws-cdk/core'
+import { mocked } from 'ts-jest/utils'
+import { CDKPipelineDeploy, ICDKPipelineDeployProps } from '../src/cdk-pipeline-deploy'
 
 export const mockHostedZoneFromLookup = (response?: any) => {
   jest.mock('@aws-cdk/aws-route53')
@@ -18,17 +22,19 @@ export const mockHostedZoneFromLookup = (response?: any) => {
   })
 }
 
-export const mockDockerCredentials = (response?: any) => {
-  jest.mock('@aws-cdk/aws-secretsmanager')
-  const mockCredentialsFromLookup = jest.spyOn(Secret, 'fromSecretNameV2')
-  mockCredentialsFromLookup.mockImplementation((scope, id, query) => {
-    return response ?? {
-      secretName: 'test-secret',
-      grantRead: (grantee: IGrantable) => (grantee),
-    }
-  },
-  )
+/**
+ * Provides a function that can be passed as a mock constructor for the CDKPipelineDeploy project
+ * such as in a mockImplementation call. We can do more to mock out the actual module later if it's
+ * ever moved to ndlib-cdk.
+ */
+export const mockCDKPipelineDeploy = (scope: Construct, id: string, props: ICDKPipelineDeployProps) => {
+  const mock = {
+    project: { addToRolePolicy: jest.fn() },
+    action: { actionProperties: { actionName: 'MockedCDKPipelineDeployAction' }, bind: jest.fn(() => ({ configuration: undefined })) },
+  }
+  return mock as unknown as CDKPipelineDeploy
 }
+
 /**
  * Synthesizes the given stack in test and returns the properties for the given
  * logical id.


### PR DESCRIPTION
The main purpose of this is to better separate the way we test pipelines
before we do more of this. We have a reusable CDKPipelineDeploy class
that is responsible for generating the PipelineProject used to perform
the cdk deploy commands. These can be a little messy to test since it's
dealing with stringified jsons for buildspecs, so testing these can be
brittle and error prone. Ideally we should test this class to make sure
that cdk command is properly generated given a set of inputs, then pipeline
tests should only need to check that it calls the CDKPipelineDeploy with
the correct properties for its test and production deploy actions. This
should eliminate repeatedly writing pipeline tests that are really just
testing the behavior of this class.

Changes:
- Add placeholders for testing CDKPipelineDeploy class.
- Refactored the buzz pipeline tests as an example of mocking out and
testing the usage of the CDKPipelineDeploy class in the buzz pipeline.
- Mocking out a locally included class is a bit tricky in js. Added the
givens module to do lazy evals like in rspec. This allows us to dry up
some of the Construct instantiations similar to the way we were using the
stack() function, while still allowing us to instantiate a new subject
after mocking is done within the test scope.
- Changed the setup in the tests to have more explicit and unique values
to allow for more accurately testing how those passed in props are used.
- While refactoring the tests, found several inconsistencies in usage of
env in the buzz pipeline that was causing some bugs in the pipeline with
things like createDns, networkStackName, domainStackName. There was a lot
of overlap between the env object and some of the props being required.
- Also found an error with the pipeline not using the hostname prefix from
props. This would have caused collisions in dev with the dns record since
it was previously a constant of buzz-test and buzz.
- Removed mock credentials helper. Doesn't appear to be needed.