### PR TITLE
Integrate the stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,27 +29,124 @@ If there are many style issues, you may want to just let the linter fix them for
 ```sh
 npm run format
 ```
+
 ## AWS prerequisites
 
 Some stacks require secrets that get pulled from parameter store. If secrets do not exist then you can create them (replace `<value>` with the actual secret) by running the following:
 
 ```sh
-aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/dec-honeypot/secret_key_base" --description "Secret key base for verifying signed cookies" --value '<value>'
+namespace="dec"
+
+aws ssm put-parameter --region us-east-1 --type 'String' --name "/all/${namespace}-foundation/sg_database_connect" --description "Database SG to attach to services that need DB connections" --value '<value>'
+
+aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-honeypot/secret_key_base" --description "Secret key base for verifying signed cookies" --value '<value>'
+
+aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-buzz/rails-secret-key-base" --description "Buzz rails secret key base" --value '<value>'
+aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-buzz/database/database" --description "Buzz database name" --value '<value>'
+aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-buzz/database/host" --description "Buzz database hostname" --value '<value>'
+aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-buzz/database/port" --description "Buzz database port" --value '<value>'
+aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-buzz/database/username" --description "Buzz database username" --value '<value>'
+aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-buzz/database/password" --description "Buzz database password" --value '<value>'
+aws ssm put-parameter --region us-east-1 --type 'String'       --name "/all/${namespace}-buzz/rails-env" --description "Buzz rails environment" --value '<value>'
+
+aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-honeycomb/rails-secret-key-base" --description "Honeycomb rails secret key base" --value '<value>'
+aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-honeycomb/database/database" --description "Honeycomb database name" --value '<value>'
+aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-honeycomb/database/host" --description "Honeycomb database hostname" --value '<value>'
+aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-honeycomb/database/username" --description "Honeycomb database username" --value '<value>'
+aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-honeycomb/database/password" --description "Honeycomb database password" --value '<value>'
+aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-honeycomb/secrets/okta/client_id" --description "Honeycomb Okta client id" --value '<value>'
+aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-honeycomb/secrets/okta/client_secret" --description "Honeycomb Okta client secret" --value '<value>'
+aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-honeycomb/secrets/okta/logout_url" --description "Honeycomb Okta logout url" --value '<value>'
+aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-honeycomb/secrets/okta/redirect_url" --description "Honeycomb Okta redirect url" --value '<value>'
+aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-honeycomb/secrets/okta/base_auth_url" --description "Honeycomb Okta base auth url" --value '<value>'
+aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-honeycomb/secrets/okta/auth_server_id" --description "Honeycomb Okta auth server id" --value '<value>'
+aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-honeycomb/secrets/google/client_id" --description "Honeycomb Google client id" --value '<value>'
+aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-honeycomb/secrets/google/client_secret" --description "Honeycomb Google client secret" --value '<value>'
+aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-honeycomb/secrets/google/developer_key" --description "Honeycomb Google developer key" --value '<value>'
+aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-honeycomb/secrets/google/app_id" --description "Honeycomb Google app id" --value '<value>'
 ```
 
 ## How to deploy
 
-TODO: [ESU-1475] Fill in more details once we get further into the project
+### Development Stacks
+
+This is a multi-stack cdk application that can deploy services independently of one another. All services are built on top of a foundation stack that will create shared resources such as log groups and log buckets. When deploying this application, you must specify an environment and the stack name.
+
+Example to deploy the foundation stack to the dev account:
+
+`cdk deploy -c env=dev dec-foundation`
+
+To see all stacks that can be deployed with this application, use `cdk list`. Example:
 
 ```sh
-cdk deploy <stackname>
+$ cdk list -c env=dev
+dec-foundation
+dec-beehive
+dec-buzz
+dec-honeycomb
+dec-honeypot
 ```
 
-### Context Overrides
+When deploying a dev stack in testlibnd, it's best to separate your stacks and DNS from other developers. Examples:
 
-| Context Key | Description |
-| ----------- | ------------|
-| namespace   | Allows deploying stacks and resources under a different namespace from the default of `dec`. Ex: `cdk deploy -c namespace=mydec mydec-foundation` |
+```sh
+namespace=my-dec
+cdk deploy -c namespace=${namespace} ${namespace}-foundation
+cdk deploy -c namespace=${namespace} -c "honeypot:hostnamePrefix=my-honeypot-dev" ${namespace}-honeypot
+cdk deploy -c namespace=${namespace} -c "buzz:hostnamePrefix=my-buzz-dev" ${namespace}-buzz
+cdk deploy -c namespace=${namespace} -c "beehive:hostnamePrefix=my-collections-dev" ${namespace}-beehive
+cdk deploy -c namespace=${namespace} \
+  -c "buzz:hostnamePrefix=my-buzz-dev" \
+  -c "beehive:hostnamePrefix=my-collections-dev" \
+  -c "honeypot:hostnamePrefix=my-honeypot-dev" \
+  ${namespace}-honeycomb
+```
+
+### Production Pipelines
+
+Create necessary ssm keys above. You'll need to do this for both `dec-test` and `dec-prod` namespaces. Then deploy the foundation and pipeline stacks:
+
+```sh
+cdk deploy -c env=prod -c stackType=pipeline dec-*-foundation dec-*-pipeline
+```
+
+## Context overrides
+
+There are a number of context values that can be overridden on the cli at deploy time that will change how and where the stacks are deployed.
+
+### AWS Environment
+
+Use the `env` context to determine what AWS account to deploy to and what configuration to use when deploying to that account. Possible values:
+
+- `dev` - Use when deploying to our development account (testlibnd).
+- `prod` - Use when deploying to our production account (libnd).
+
+Example deploy of all service stacks to our dev account:
+
+`cdk deploy -c env=dev ...`
+
+### Stack type
+
+Stacks are split into two different types. The type chosen will determine what stacks are available for a cdk deploy. Possible values:
+
+- `service` (default) - These will deploy the service stacks. You will use this type most often used when deploying an individual stack in development, or within a deployment pipeline.
+- `pipeline` - These are deployment pipelines that will perform continuous deployment of the service stacks
+
+Example deploy of all deployment pipelines to our development account:
+
+`cdk deploy -c env=dev -c stackType=pipeline ...`
+
+### Stack namespace
+
+All stacks are prefixed with a stack namespace. By default, this is `marble` but can be changed so that you can separate your stacks from any others. This is useful for developers who share a development account, or when performing a side-by-side deployment to production to reduce downtime.
+
+Example deploy of the Honeycomb stack with a different stack namespace:
+
+`cdk deploy -c env=dev -c namespace=foo foo-honeycomb`
+
+### Others
+
+To view all other context keys that can be overridden, use `cdk context`.
 
 ## Other useful commands
 

--- a/bin/pipelines.ts
+++ b/bin/pipelines.ts
@@ -5,6 +5,7 @@ import { getContextByNamespace } from '../src/context-helpers'
 import { FoundationStack } from '../src/foundation-stack'
 import { BuzzStack } from '../src/buzz/buzz-stack'
 import { BuzzPipelineStack } from '../src/buzz/buzz-pipeline'
+import { PipelineFoundationStack } from '../src/pipeline-foundation-stack'
 
 export const instantiateStacks = (app: App, namespace: string, env: CustomEnvironment, testStacks: Stacks, prodStacks: Stacks): Stacks => {
   const infraRepoName = app.node.tryGetContext('infraRepoName')
@@ -12,7 +13,8 @@ export const instantiateStacks = (app: App, namespace: string, env: CustomEnviro
   const infraSourceBranch = app.node.tryGetContext('infraSourceBranch')
   const dockerhubCredentialsPath = app.node.tryGetContext('dockerhubCredentialsPath')
   const oauthTokenPath = app.node.tryGetContext('oauthTokenPath')
-
+  
+  const pipelineFoundationStack = new PipelineFoundationStack(app, `${namespace}-deployment-foundation`, { env })
   const commonProps = {
     namespace,
     env: env,
@@ -21,15 +23,14 @@ export const instantiateStacks = (app: App, namespace: string, env: CustomEnviro
     infraSourceBranch: infraSourceBranch,
     dockerhubCredentialsPath: dockerhubCredentialsPath,
     oauthTokenPath: oauthTokenPath,
+    pipelineFoundationStack,
+    testFoundationStack: testStacks.foundationStack,
+    prodFoundationStack: prodStacks.foundationStack,
   }
 
-  const foundationStack = new FoundationStack(app, `${namespace}-foundation`, {
-    ...commonProps,
-  })
 
   const buzzContext = getContextByNamespace('buzz')
   const buzzPipelineStack = new BuzzPipelineStack(app, `${namespace}-buzz-pipeline`, {
-    foundationStack,
     testStack: testStacks.BuzzStack,
     prodStack: prodStacks.BuzzStack,
     ...commonProps,

--- a/bin/pipelines.ts
+++ b/bin/pipelines.ts
@@ -13,7 +13,7 @@ export const instantiateStacks = (app: App, namespace: string, env: CustomEnviro
   const infraSourceBranch = app.node.tryGetContext('infraSourceBranch')
   const dockerhubCredentialsPath = app.node.tryGetContext('dockerhubCredentialsPath')
   const oauthTokenPath = app.node.tryGetContext('oauthTokenPath')
-  
+
   const pipelineFoundationStack = new PipelineFoundationStack(app, `${namespace}-deployment-foundation`, { env })
   const commonProps = {
     namespace,
@@ -27,7 +27,6 @@ export const instantiateStacks = (app: App, namespace: string, env: CustomEnviro
     testFoundationStack: testStacks.foundationStack,
     prodFoundationStack: prodStacks.foundationStack,
   }
-
 
   const buzzContext = getContextByNamespace('buzz')
   const buzzPipelineStack = new BuzzPipelineStack(app, `${namespace}-buzz-pipeline`, {

--- a/bin/services.ts
+++ b/bin/services.ts
@@ -14,36 +14,38 @@ export const instantiateStacks = (app: App, namespace: string, env: CustomEnviro
     namespace,
     env: env,
   }
+
+  const honeycombContext = getContextByNamespace('honeycomb')
+  const beehiveContext = getContextByNamespace('beehive')
+  const buzzContext = getContextByNamespace('buzz')
+  const honeypotContext = getContextByNamespace('honeypot')
+
   const foundationStack = new FoundationStack(app, `${namespace}-foundation`, {
+    honeycombHostnamePrefix: honeycombContext.hostnamePrefix,
     ...commonProps,
   })
-
-  const beehiveContext = getContextByNamespace('beehive')
   const beehiveStack = new BeehiveStack(app, `${namespace}-beehive`, {
     foundationStack,
     ...commonProps,
     ...beehiveContext,
   })
-
-  const honeycombContext = getContextByNamespace('honeycomb')
-  const honeycombStack = new HoneycombStack(app, `${namespace}-honeycomb`, {
-    foundationStack,
-    ...commonProps,
-    ...honeycombContext,
-  })
-
-  const buzzContext = getContextByNamespace('buzz')
   const buzzStack = new BuzzStack(app, `${namespace}-buzz`, {
     foundationStack,
     ...commonProps,
     ...buzzContext,
   })
-
-  const honeypotContext = getContextByNamespace('honeypot')
   const honeypotStack = new HoneypotStack(app, `${namespace}-honeypot`, {
     foundationStack,
     ...commonProps,
     ...honeypotContext,
+  })
+  const honeycombStack = new HoneycombStack(app, `${namespace}-honeycomb`, {
+    foundationStack,
+    honeypotStack,
+    buzzStack,
+    beehiveStack,
+    ...commonProps,
+    ...honeycombContext,
   })
 
   return { foundationStack, beehiveStack, buzzStack, honeycombStack, honeypotStack }

--- a/cdk.context.json
+++ b/cdk.context.json
@@ -58,8 +58,7 @@
     "Id": "/hostedzone/Z3X1BGRWFJ8Z8",
     "Name": "libraries.nd.edu."
   },
-  "ssm:account=333680067100:parameterName=/all/jg-honeycomb/sg_database_connect:region=us-east-1": "sg-0a05476fba09d7e71",
-  "ssm:account=333680067100:parameterName=/all/jg-dec-honeycomb/sg_database_connect:region=us-east-1": "sg-0a05476fba09d7e71",
-  "ssm:account=230391840102:parameterName=/all/buzz/sg_database_connect:region=us-east-1": "sg-05593041929017eb2",
-  "ssm:account=333680067100:parameterName=/all/buzz/sg_database_connect:region=us-east-1": "sg-0a05476fba09d7e71"
+  "ssm:account=333680067100:parameterName=/all/jg-dec-foundation/sg_database_connect:region=us-east-1": "sg-0a05476fba09d7e71",
+  "ssm:account=333680067100:parameterName=/all/jg-dec-prod-foundation/sg_database_connect:region=us-east-1": "sg-0a05476fba09d7e71",
+  "ssm:account=333680067100:parameterName=/all/jg-dec-test-foundation/sg_database_connect:region=us-east-1": "sg-0a05476fba09d7e71"
 }

--- a/src/buzz/buzz-pipeline.ts
+++ b/src/buzz/buzz-pipeline.ts
@@ -13,8 +13,8 @@ import { NamespacedPolicy, GlobalActions } from '../namespaced-policy'
 import { CustomEnvironment } from '../custom-environment'
 import { FoundationStack } from '../foundation-stack'
 import { DockerhubImage } from '../dockerhub-image'
-import cdk = require('@aws-cdk/core')
 import { PipelineFoundationStack } from '../pipeline-foundation-stack'
+import cdk = require('@aws-cdk/core')
 
 export interface CDPipelineStackProps extends cdk.StackProps {
   readonly env: CustomEnvironment;
@@ -60,10 +60,10 @@ const addPermissions = (deploy: CDKPipelineDeploy, namespace: string, foundation
   // Have to just use a constant prefix regardless of whether its test or prod stack name.
   deploy.project.addToRolePolicy(new PolicyStatement({
     resources: [
-      cdk.Fn.sub('arn:aws:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:targetgroup/' + namespace.substring(0,5) + '-*/*'),
-      cdk.Fn.sub('arn:aws:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:loadbalancer/app/' + namespace.substring(0,5) + '-*/*'),
-      cdk.Fn.sub('arn:aws:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:listener/app/' + namespace.substring(0,5) + '-*/*'),
-      cdk.Fn.sub('arn:aws:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:listener-rule/app/' + namespace.substring(0,5) + '-*/*'),
+      cdk.Fn.sub('arn:aws:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:targetgroup/' + namespace.substring(0, 5) + '-*/*'),
+      cdk.Fn.sub('arn:aws:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:loadbalancer/app/' + namespace.substring(0, 5) + '-*/*'),
+      cdk.Fn.sub('arn:aws:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:listener/app/' + namespace.substring(0, 5) + '-*/*'),
+      cdk.Fn.sub('arn:aws:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:listener-rule/app/' + namespace.substring(0, 5) + '-*/*'),
     ],
     actions: [
       'elasticloadbalancing:AddTags',

--- a/src/buzz/buzz-stack.ts
+++ b/src/buzz/buzz-stack.ts
@@ -4,17 +4,16 @@ import {
   Cluster,
   FargateService,
   FargateTaskDefinition,
-  Secret,
 } from '@aws-cdk/aws-ecs'
-import { Peer, Port, SecurityGroup, SubnetType } from '@aws-cdk/aws-ec2'
-import { ApplicationListenerRule, ApplicationProtocol, ApplicationTargetGroup } from '@aws-cdk/aws-elasticloadbalancingv2'
-import { PolicyStatement } from '@aws-cdk/aws-iam'
-import { LogGroup, RetentionDays } from '@aws-cdk/aws-logs'
-import { StringParameter } from '@aws-cdk/aws-ssm'
+import { SecurityGroup, SubnetType } from '@aws-cdk/aws-ec2'
+import { ApplicationListenerRule, ApplicationProtocol, ApplicationTargetGroup, Protocol, TargetType } from '@aws-cdk/aws-elasticloadbalancingv2'
 import { CustomEnvironment } from '../custom-environment'
 import { SharedServiceStackProps } from '../shared-stack-props'
-import { HttpsAlb } from '@ndlib/ndlib-cdk'
 import { AssetHelpers } from '../asset-helpers'
+import { CnameRecord, HostedZone } from '@aws-cdk/aws-route53'
+import { ECSSecretsHelper } from '../ecs-secrets-helpers'
+import { Duration } from '@aws-cdk/core'
+import { StringParameter } from '@aws-cdk/aws-ssm'
 
 export interface BuzzStackProps extends SharedServiceStackProps {
   readonly env: CustomEnvironment,
@@ -23,38 +22,28 @@ export interface BuzzStackProps extends SharedServiceStackProps {
 }
 
 export class BuzzStack extends cdk.Stack {
+  public readonly hostname: string
+
   constructor (scope: cdk.Construct, id: string, props: BuzzStackProps) {
     super(scope, id, props)
 
-    const loadBalancer = new HttpsAlb(this, 'loadBalancer', {
-      internetFacing: true,
-      vpc: props.foundationStack.vpc,
-      certificateArns: [props.foundationStack.certificate.certificateArn],
-    })
-
-    const databaseConnectSecurityGroupParam = StringParameter.valueFromLookup(this, '/all/buzz/sg_database_connect')
-    const connectSecurityGroup = SecurityGroup.fromSecurityGroupId(this, 'PostgreSqlSG', databaseConnectSecurityGroupParam)
     const appSecurityGroup = new SecurityGroup(this, 'AppSecurityGroup', {
       vpc: props.foundationStack.vpc,
       allowAllOutbound: true,
     })
 
-    appSecurityGroup.addIngressRule(Peer.anyIpv4(), Port.tcp(80), 'allow all inbound on 80')
+    const domainNameImport = cdk.Fn.importValue(`${props.env.domainStackName}:DomainName`)
+    this.hostname = `${props.hostnamePrefix}.${domainNameImport}`
 
+    // Define Security Groups needed for service
+    const securityGroups = [
+      props.foundationStack.databaseSecurityGroup,
+      appSecurityGroup,
+    ]
     const logging = new AwsLogDriver({
       streamPrefix: `${this.stackName}-Task`,
-      logGroup: new LogGroup(this, `${this.stackName}`, {
-        retention: RetentionDays.ONE_WEEK,
-      }),
+      logGroup: props.foundationStack.logs,
     })
-
-    const secretsHelper = (task: string, key: string) => {
-      const parameter = StringParameter.fromSecureStringParameterAttributes(this, `${task}${key}`, {
-        parameterName: `/all/${this.stackName}/${key}`,
-        version: 1, // This doesn't seem to matter in the context of ECS task definitions
-      })
-      return Secret.fromSsmParameter(parameter)
-    }
 
     const railsDockerImage = AssetHelpers.containerFromDockerfile(this, 'RailsImageAsset', {
       directory: props.appDirectory,
@@ -71,59 +60,76 @@ export class BuzzStack extends cdk.Stack {
         PORT: '80',
         AWS_REGION: this.region,
         RAILS_LOG_TO_STDOUT: 'true',
+        DEFAULT_URL_HOST: this.hostname,
+        DEFAULT_URL_PROTOCOL: 'http',
+        WOWZA_HOST: 'wowza.library.nd.edu',
+        WOWZA_PORT: '443',
+        WOWZA_APPLICATION: 'buzz_wow',
+        WOWZA_INSTANCE: '_definst_',
+        WOWZA_CACHE_PREFIX: 'amazons3',
+        WOWZA_CACHE_SOURCE: props.foundationStack.mediaBucket.bucketName,
       },
       secrets: {
-        RAILS_ENV: secretsHelper('RailsService', 'rails_env'),
-        RDS_PORT: secretsHelper('RailsService', 'database/port'),
-        RDS_USERNAME: secretsHelper('RailsService', 'database/username'),
-        RDS_PASSWORD: secretsHelper('RailsService', 'database/password'),
-        RDS_DB_NAME: secretsHelper('RailsService', 'database/database'),
-        RDS_HOSTNAME: secretsHelper('RailsService', 'database/host'),
-        RAILS_SECRET_KEY_BASE: secretsHelper('RailsService', 'rails-secret-key-base'),
+        RAILS_ENV: ECSSecretsHelper.fromSSM(this, 'RailsService', 'rails-env'),
+        RDS_PORT: ECSSecretsHelper.fromSSM(this, 'RailsService', 'database/port'),
+        RDS_USERNAME: ECSSecretsHelper.fromSSM(this, 'RailsService', 'database/username'),
+        RDS_PASSWORD: ECSSecretsHelper.fromSSM(this, 'RailsService', 'database/password'),
+        RDS_DB_NAME: ECSSecretsHelper.fromSSM(this, 'RailsService', 'database/database'),
+        RDS_HOSTNAME: ECSSecretsHelper.fromSSM(this, 'RailsService', 'database/host'),
+        RAILS_SECRET_KEY_BASE: ECSSecretsHelper.fromSSM(this, 'RailsService', 'rails-secret-key-base'),
       },
     })
-
     rails.addPortMappings({
       containerPort: 80,
     })
 
     appTaskDefinition.defaultContainer = rails
-
     const appService = new FargateService(this, 'AppService', {
       taskDefinition: appTaskDefinition,
-      cluster: new Cluster(this, 'AppCluster', { vpc: props.foundationStack.vpc }),
+      cluster: props.foundationStack.cluster,
       vpcSubnets: { subnetType: SubnetType.PRIVATE },
       desiredCount: 1,
-      securityGroups: [appSecurityGroup, connectSecurityGroup],
+      securityGroups,
     })
-
-    appTaskDefinition.addToTaskRolePolicy(new PolicyStatement({
-      actions: [
-        'ssm:*',
-      ],
-      resources: [
-        cdk.Fn.sub(`arn:aws:ssm:${this.region}:${this.account}:parameter/all/${this.stackName}/*`),
-      ],
-    }))
 
     const loadBalancerTargetGroup = new ApplicationTargetGroup(this, 'ApplicationTargetGroup', {
       healthCheck: {
         enabled: true,
         path: '/',
-        timeout: cdk.Duration.seconds(10),
+        protocol: Protocol.HTTP,
+        interval: Duration.seconds(30),
+        timeout: Duration.seconds(10),
         healthyThresholdCount: 2,
+        unhealthyThresholdCount: 10,
+        port: '80',
+        healthyHttpCodes: '200',
       },
       vpc: props.foundationStack.vpc,
       protocol: ApplicationProtocol.HTTP,
       targets: [appService],
+      deregistrationDelay: Duration.seconds(60),
+      targetType: TargetType.IP,
+      port: 80,
     })
 
-    new ApplicationListenerRule(this, 'ApplicationListenerRule', { // eslint-disable-line no-new
-      listener: loadBalancer.defaultListener,
+    new ApplicationListenerRule(this, 'ApplicationListenerRule', {
+      listener: props.foundationStack.publicLoadBalancer.defaultListener,
       priority: 1,
       pathPattern: '*',
-      hostHeader: `${props.hostnamePrefix}.` + cdk.Fn.importValue(`${props.env.domainStackName}:DomainName`),
+      hostHeader: this.hostname,
       targetGroups: [loadBalancerTargetGroup],
     })
+
+    if (props.env.createDns) {
+      const cnameRecord = new CnameRecord(this, 'ServiceCNAME', {
+        recordName: props.hostnamePrefix,
+        domainName: props.foundationStack.publicLoadBalancer.loadBalancerDnsName,
+        zone: HostedZone.fromHostedZoneAttributes(this, 'ImportedHostedZone', {
+          hostedZoneId: cdk.Fn.importValue(`${props.env.domainStackName}:Zone`),
+          zoneName: domainNameImport,
+        }),
+        ttl: cdk.Duration.minutes(15),
+      })
+    }
   }
 }

--- a/src/buzz/buzz-stack.ts
+++ b/src/buzz/buzz-stack.ts
@@ -112,7 +112,7 @@ export class BuzzStack extends cdk.Stack {
       port: 80,
     })
 
-    new ApplicationListenerRule(this, 'ApplicationListenerRule', {
+    const buzzRule = new ApplicationListenerRule(this, 'ApplicationListenerRule', {
       listener: props.foundationStack.publicLoadBalancer.defaultListener,
       priority: 1,
       pathPattern: '*',

--- a/src/cdk-pipeline-migrate.ts
+++ b/src/cdk-pipeline-migrate.ts
@@ -49,7 +49,6 @@ export class RailsMigration extends Construct {
     constructor (scope: Construct, id: string, props: ICDKPipelineDeployProps) {
       super(scope, id)
 
-
       const migrateSecurityGroup = new SecurityGroup(this, 'MigrateSecurityGroup', {
         vpc: props.foundationStack.vpc,
       })

--- a/src/cdk-pipeline-migrate.ts
+++ b/src/cdk-pipeline-migrate.ts
@@ -49,14 +49,7 @@ export class RailsMigration extends Construct {
     constructor (scope: Construct, id: string, props: ICDKPipelineDeployProps) {
       super(scope, id)
 
-      //   let addtlContext = ''
-      //   if (props.additionalContext !== undefined) {
-      //     Object.entries(props.additionalContext).forEach((val) => {
-      //       addtlContext += ` -c "${val[0]}=${val[1]}"`
-      //     })
-      //   }
-      const databaseConnectSecurityGroupId = StringParameter.valueFromLookup(this, '/all/buzz/sg_database_connect')
-      const databaseConnectSecurityGroup = SecurityGroup.fromSecurityGroupId(this, 'databaseConnectSG', databaseConnectSecurityGroupId)
+
       const migrateSecurityGroup = new SecurityGroup(this, 'MigrateSecurityGroup', {
         vpc: props.foundationStack.vpc,
       })
@@ -70,7 +63,7 @@ export class RailsMigration extends Construct {
         vpc: props.foundationStack.vpc,
         securityGroups: [
           migrateSecurityGroup,
-          databaseConnectSecurityGroup,
+          props.foundationStack.databaseSecurityGroup,
         ],
         environment: {
           buildImage: LinuxBuildImage.fromDockerRegistry('ruby:2.4.4', {
@@ -100,8 +93,8 @@ export class RailsMigration extends Construct {
             type: BuildEnvironmentVariableType.PARAMETER_STORE,
           },
           RAILS_ENV: {
-            value: `/all/${props.ssmPrefix}/rails_env`,
-            type: BuildEnvironmentVariableType.PARAMETER_STORE,
+            value: 'production',
+            type: BuildEnvironmentVariableType.PLAINTEXT,
           },
           RAILS_SECRET_KEY_BASE: {
             value: `/all/${props.ssmPrefix}/rails-secret-key-base`,

--- a/src/foundation-stack.ts
+++ b/src/foundation-stack.ts
@@ -102,10 +102,10 @@ export class FoundationStack extends cdk.Stack {
     this.mediaBucket = new Bucket(this, 'mediaBucket', {
       publicReadAccess: true,
       cors: [{
-        allowedHeaders: [ '*' ],
-        allowedMethods: [ HttpMethods.GET, HttpMethods.PUT, HttpMethods.POST ],
-        allowedOrigins: [ `https://${props.honeycombHostnamePrefix}.${props.env.domainName}` ],
-        exposedHeaders: [ 'ETag' ],
+        allowedHeaders: ['*'],
+        allowedMethods: [HttpMethods.GET, HttpMethods.PUT, HttpMethods.POST],
+        allowedOrigins: [`https://${props.honeycombHostnamePrefix}.${props.env.domainName}`],
+        exposedHeaders: ['ETag'],
         maxAge: 3000,
       }],
     })

--- a/src/foundation-stack.ts
+++ b/src/foundation-stack.ts
@@ -1,29 +1,35 @@
 import * as cdk from '@aws-cdk/core'
-import { Bucket, BucketAccessControl, BucketEncryption } from '@aws-cdk/aws-s3'
+import { Bucket, BucketAccessControl, HttpMethods } from '@aws-cdk/aws-s3'
 import { Certificate, CertificateValidation, ICertificate } from '@aws-cdk/aws-certificatemanager'
-import { Vpc } from '@aws-cdk/aws-ec2'
+import { ISecurityGroup, SecurityGroup, Vpc } from '@aws-cdk/aws-ec2'
 import { HostedZone, IHostedZone } from '@aws-cdk/aws-route53'
 import { CustomEnvironment } from './custom-environment'
 import { LogGroup, RetentionDays } from '@aws-cdk/aws-logs'
 import { PrivateDnsNamespace } from '@aws-cdk/aws-servicediscovery'
 import { HttpsAlb } from '@ndlib/ndlib-cdk'
-
 import { Cluster } from '@aws-cdk/aws-ecs'
+import { StringParameter } from '@aws-cdk/aws-ssm'
 
 export interface FoundationStackProps extends cdk.StackProps {
   readonly env: CustomEnvironment
+
+  /**
+   * The hostname for honeycomb to add as an allowed origin in the media bucket
+   */
+  readonly honeycombHostnamePrefix: string
 }
 
 export class FoundationStack extends cdk.Stack {
   public readonly vpc: Vpc
   public readonly logBucket: Bucket
-  public readonly artifactBucket: Bucket
   public readonly certificate: ICertificate
   public readonly hostedZone: IHostedZone
   public readonly logs: LogGroup
   public readonly publicLoadBalancer: HttpsAlb
   public readonly cluster: Cluster
   public readonly privateNamespace: PrivateDnsNamespace
+  public readonly mediaBucket: Bucket
+  public readonly databaseSecurityGroup: ISecurityGroup
 
   constructor (scope: cdk.Construct, id: string, props: FoundationStackProps) {
     super(scope, id, props)
@@ -92,9 +98,19 @@ export class FoundationStack extends cdk.Stack {
       description: 'Private Namespace for DEC',
     })
 
-    this.artifactBucket = new Bucket(this, 'artifactBucket', {
-      encryption: BucketEncryption.KMS_MANAGED,
-      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    // TODO: Add CORS
+    this.mediaBucket = new Bucket(this, 'mediaBucket', {
+      publicReadAccess: true,
+      cors: [{
+        allowedHeaders: [ '*' ],
+        allowedMethods: [ HttpMethods.GET, HttpMethods.PUT, HttpMethods.POST ],
+        allowedOrigins: [ `https://${props.honeycombHostnamePrefix}.${props.env.domainName}` ],
+        exposedHeaders: [ 'ETag' ],
+        maxAge: 3000,
+      }],
     })
+
+    const databaseSecurityGroupParameter = StringParameter.valueFromLookup(this, `/all/${this.stackName}/sg_database_connect`)
+    this.databaseSecurityGroup = SecurityGroup.fromSecurityGroupId(this, 'PostgreSQLConnect', databaseSecurityGroupParameter)
   }
 }

--- a/src/honeycomb/honeycomb-stack.ts
+++ b/src/honeycomb/honeycomb-stack.ts
@@ -3,10 +3,14 @@ import { SecurityGroup } from '@aws-cdk/aws-ec2'
 import { FoundationStack } from '../foundation-stack'
 import { Construct, RemovalPolicy, Stack } from '@aws-cdk/core'
 import { FileSystem, LifecyclePolicy } from '@aws-cdk/aws-efs'
+import { StringParameter } from '@aws-cdk/aws-ssm'
 import { CustomEnvironment } from '../custom-environment'
 import { SolrConstruct } from './solr-construct'
 import { RabbitMqConstruct } from './rabbitmq-construct'
 import { RailsConstruct } from './rails-construct'
+import { HoneypotStack } from '../honeypot-stack'
+import { BuzzStack } from '../buzz/buzz-stack'
+import { BeehiveStack } from '../beehive-stack'
 
 export interface HoneycombStackProps extends SharedServiceStackProps {
   /**
@@ -23,6 +27,10 @@ export interface HoneycombStackProps extends SharedServiceStackProps {
    * The foundation to build this stack on top of
    */
   readonly foundationStack: FoundationStack
+
+  readonly honeypotStack: HoneypotStack
+  readonly buzzStack: BuzzStack
+  readonly beehiveStack: BeehiveStack
 
   /**
    * Hostname to use when adding to the public facing load balancer and dns
@@ -73,9 +81,14 @@ export class HoneycombStack extends Stack {
       appDirectory: props.appDirectory,
       hostnamePrefix: props.hostnamePrefix,
       appSecurityGroup,
+      databaseSecurityGroup: props.foundationStack.databaseSecurityGroup,
       fileSystem,
       solr,
       rabbitMq,
+      honeypot: props.honeypotStack,
+      buzz: props.buzzStack,
+      beehive: props.beehiveStack,
+      mediaBucket: props.foundationStack.mediaBucket,
     })
   }
 }

--- a/src/honeycomb/rails-construct.ts
+++ b/src/honeycomb/rails-construct.ts
@@ -20,10 +20,10 @@ import { RabbitMqConstruct } from './rabbitmq-construct'
 import { PrivateDnsNamespace } from '@aws-cdk/aws-servicediscovery'
 import { HttpsAlb } from '@ndlib/ndlib-cdk'
 import { ECSSecretsHelper } from '../ecs-secrets-helpers'
-import elbv2 = require('@aws-cdk/aws-elasticloadbalancingv2')
 import { HoneypotStack } from '../honeypot-stack'
 import { BeehiveStack } from '../beehive-stack'
 import { BuzzStack } from '../buzz/buzz-stack'
+import elbv2 = require('@aws-cdk/aws-elasticloadbalancingv2')
 
 export interface RailsConstructProps {
   /**
@@ -125,6 +125,8 @@ export class RailsConstruct extends Construct {
       SOLR_PORT: '8983',
       RAILS_ENV: 'production',
       RAILS_LOG_TO_STDOUT: 'true',
+      RAILS_LOG_LEVEL: 'DEBUG',
+      RAILS_LOG_AUTOFLUSH: 'true',
       RABBIT_HOST: props.rabbitMq.hostname,
       RABBIT_VHOST: '/',
       HONEYCOMB_HOST: this.hostname,

--- a/src/honeycomb/rails-construct.ts
+++ b/src/honeycomb/rails-construct.ts
@@ -1,4 +1,4 @@
-import { Port, SecurityGroup, Vpc } from '@aws-cdk/aws-ec2'
+import { Port, ISecurityGroup, SecurityGroup, Vpc } from '@aws-cdk/aws-ec2'
 import {
   AwsLogDriver,
   FargatePlatformVersion,
@@ -7,8 +7,8 @@ import {
   Secret,
   Cluster,
 } from '@aws-cdk/aws-ecs'
+import { Bucket } from '@aws-cdk/aws-s3'
 import { CnameRecord, HostedZone } from '@aws-cdk/aws-route53'
-import { StringParameter } from '@aws-cdk/aws-ssm'
 import { LogGroup } from '@aws-cdk/aws-logs'
 import { AssetHelpers } from '../asset-helpers'
 import { Construct, Duration, Fn, Stack } from '@aws-cdk/core'
@@ -21,6 +21,9 @@ import { PrivateDnsNamespace } from '@aws-cdk/aws-servicediscovery'
 import { HttpsAlb } from '@ndlib/ndlib-cdk'
 import { ECSSecretsHelper } from '../ecs-secrets-helpers'
 import elbv2 = require('@aws-cdk/aws-elasticloadbalancingv2')
+import { HoneypotStack } from '../honeypot-stack'
+import { BeehiveStack } from '../beehive-stack'
+import { BuzzStack } from '../buzz/buzz-stack'
 
 export interface RailsConstructProps {
   /**
@@ -82,19 +85,27 @@ export interface RailsConstructProps {
    * Reference to the RabbitMq instance that Rails should use
    */
   readonly rabbitMq: RabbitMqConstruct
+
+  readonly honeypot: HoneypotStack
+  readonly beehive: BeehiveStack
+  readonly buzz: BuzzStack
+  readonly mediaBucket: Bucket
+  readonly databaseSecurityGroup: ISecurityGroup
 }
 
 export class RailsConstruct extends Construct {
+  public readonly hostname: string
+
   constructor (scope: Construct, id: string, props:RailsConstructProps) {
     super(scope, id)
     const stack = Stack.of(this)
     const stackName = stack.stackName
+    const domainNameImport = Fn.importValue(`${props.env.domainStackName}:DomainName`)
+    this.hostname = `${props.hostnamePrefix}.${domainNameImport}`
 
     // Define Security Groups needed for service
-    const databaseSecurityGroupParameter = StringParameter.valueFromLookup(this, `/all/${stackName}/sg_database_connect`)
-    const databaseConnectSecurityGroup = SecurityGroup.fromSecurityGroupId(this, 'PostgreSQLConnect', databaseSecurityGroupParameter)
     const securityGroups = [
-      databaseConnectSecurityGroup,
+      props.databaseSecurityGroup,
       props.appSecurityGroup,
     ]
 
@@ -116,6 +127,13 @@ export class RailsConstruct extends Construct {
       RAILS_LOG_TO_STDOUT: 'true',
       RABBIT_HOST: props.rabbitMq.hostname,
       RABBIT_VHOST: '/',
+      HONEYCOMB_HOST: this.hostname,
+      HONEYPOT_HOST: `https://${props.honeypot.hostname}`,
+      BEEHIVE_HOST: `https://${props.beehive.hostname}`,
+      BUZZ_HOST: `https://${props.buzz.hostname}`,
+      MEDIA_BUCKET_REGION: stack.region,
+      MEDIA_BUCKET_NAME: props.mediaBucket.bucketName,
+      AWS_PROFILE: '', // Need to blank this out so that it doesn't try to read shared credentials from files
     }
     const railsSecrets = {
       DB_PASSWORD: ECSSecretsHelper.fromSSM(this, 'RailsService', 'rds/password'),
@@ -143,6 +161,9 @@ export class RailsConstruct extends Construct {
     const rakeTaskDefinition = new FargateTaskDefinition(this, 'RakeTaskDefinition', {
       memoryLimitMiB: 2048,
     })
+    // Give nfs access and mount the efs
+    props.appSecurityGroup.connections.allowFrom(props.fileSystem, Port.tcp(2049))
+    props.appSecurityGroup.connections.allowTo(props.fileSystem, Port.tcp(2049))
     rakeTaskDefinition.addVolume({
       name: railsEfsVolumeName,
       efsVolumeConfiguration: {
@@ -191,7 +212,7 @@ export class RailsConstruct extends Construct {
       sourceVolume: railsEfsVolumeName,
       containerPath: '/mnt/honeycomb',
     })
-
+    props.mediaBucket.grantPut(appTaskDefinition.taskRole)
     const nginxImage = AssetHelpers.containerFromDockerfile(stack, 'NginxImageAsset', {
       directory: props.appDirectory,
       file: 'docker/Dockerfile.nginx',
@@ -227,9 +248,6 @@ export class RailsConstruct extends Construct {
         name: 'honeycomb',
       },
     })
-
-    appService.connections.allowFrom(props.fileSystem, Port.tcp(2049))
-    appService.connections.allowTo(props.fileSystem, Port.tcp(2049))
     // End Rails service task
 
     const targetGroup = new elbv2.ApplicationTargetGroup(this, 'TargetGroup', {
@@ -252,11 +270,10 @@ export class RailsConstruct extends Construct {
       // This app uses sessions so need to set stickiness
       stickinessCookieDuration: Duration.minutes(10),
     })
-    const domainNameImport = Fn.importValue(`${props.env.domainStackName}:DomainName`)
     const albRule = new elbv2.ApplicationListenerRule(this, 'ECSServiceRule3', {
       targetGroups: [targetGroup],
       pathPattern: '*',
-      hostHeader: `${props.hostnamePrefix}.${domainNameImport}`,
+      hostHeader: this.hostname,
       listener: props.publicLoadBalancer.defaultListener,
       priority: 3,
     })

--- a/src/honeypot-stack.ts
+++ b/src/honeypot-stack.ts
@@ -7,11 +7,11 @@ import { CustomEnvironment } from './custom-environment'
 import { Port, SubnetType } from '@aws-cdk/aws-ec2'
 import { AssetHelpers } from './asset-helpers'
 import { ECSSecretsHelper } from './ecs-secrets-helpers'
+import { FileSystem, LifecyclePolicy } from '@aws-cdk/aws-efs'
+import { RemovalPolicy } from '@aws-cdk/core'
 import elbv2 = require('@aws-cdk/aws-elasticloadbalancingv2')
 import ecs = require('@aws-cdk/aws-ecs')
 import ssm = require('@aws-cdk/aws-ssm')
-import { FileSystem, LifecyclePolicy } from '@aws-cdk/aws-efs'
-import { RemovalPolicy } from '@aws-cdk/core'
 
 export interface HoneypotStackProps extends SharedServiceStackProps {
   readonly hostnamePrefix: string,
@@ -76,7 +76,6 @@ export class HoneypotStack extends cdk.Stack {
       sourceVolume: railsEfsVolumeName,
       containerPath: '/honeypot/public/images',
     })
-
 
     const iipImage = AssetHelpers.containerFromDockerfile(this, 'IIPImageAsset', {
       directory: props.appDirectory,

--- a/src/honeypot-stack.ts
+++ b/src/honeypot-stack.ts
@@ -1,21 +1,22 @@
 import * as cdk from '@aws-cdk/core'
-import { HttpsAlb } from '@ndlib/ndlib-cdk'
+import { FargateTaskDefinition, FargatePlatformVersion } from '@aws-cdk/aws-ecs'
 import { CnameRecord, HostedZone } from '@aws-cdk/aws-route53'
 import { SharedServiceStackProps } from './shared-stack-props'
 import { FoundationStack } from './foundation-stack'
 import { CustomEnvironment } from './custom-environment'
-import { LogGroup, RetentionDays } from '@aws-cdk/aws-logs'
-import { SubnetType, Vpc } from '@aws-cdk/aws-ec2'
+import { Port, SubnetType } from '@aws-cdk/aws-ec2'
 import { AssetHelpers } from './asset-helpers'
+import { ECSSecretsHelper } from './ecs-secrets-helpers'
 import elbv2 = require('@aws-cdk/aws-elasticloadbalancingv2')
 import ecs = require('@aws-cdk/aws-ecs')
 import ssm = require('@aws-cdk/aws-ssm')
+import { FileSystem, LifecyclePolicy } from '@aws-cdk/aws-efs'
+import { RemovalPolicy } from '@aws-cdk/core'
 
 export interface HoneypotStackProps extends SharedServiceStackProps {
   readonly hostnamePrefix: string,
   readonly env: CustomEnvironment
   readonly appDirectory: string
-  readonly foundationStack: FoundationStack
 }
 export class HoneypotStack extends cdk.Stack {
   public readonly hostname: string
@@ -23,60 +24,27 @@ export class HoneypotStack extends cdk.Stack {
   constructor (scope: cdk.Construct, id: string, props: HoneypotStackProps) {
     super(scope, id, props)
 
-    // The code that defines your stack goes here
-
-    // Networking
-    const vpcId = cdk.Fn.importValue(`${props.env.networkStackName}:VPCID`)
-    const vpc = Vpc.fromVpcAttributes(this, 'ImportedVPC', {
-      vpcId,
-      availabilityZones: [
-        // This technically doesn't matter in this context, since none of the resources in this app
-        // require AZ for their cloud formations, only subnets. But in the interest of not creating
-        // problems for future things that use this IVpc object, I'm recreating how AZs were defined
-        // for the subnets in the network stack. In those stacks, we aren't exporting the AZs for
-        // Subnet1|2 so this must match the way the subnets were created.
-        cdk.Fn.select(0, cdk.Fn.getAzs()),
-        cdk.Fn.select(1, cdk.Fn.getAzs()),
-      ],
-      publicSubnetIds: [
-        cdk.Fn.importValue(`${props.env.networkStackName}:PublicSubnet1ID`),
-        cdk.Fn.importValue(`${props.env.networkStackName}:PublicSubnet2ID`),
-      ],
-      privateSubnetIds: [
-        cdk.Fn.importValue(`${props.env.networkStackName}:PrivateSubnet1ID`),
-        cdk.Fn.importValue(`${props.env.networkStackName}:PrivateSubnet2ID`),
-      ],
+    const railsEfsVolumeName = 'rails'
+    const fileSystem = new FileSystem(this, 'FileSystem', {
+      vpc: props.foundationStack.vpc,
+      lifecyclePolicy: LifecyclePolicy.AFTER_30_DAYS,
+      removalPolicy: RemovalPolicy.DESTROY,
+      encrypted: true,
     })
-
-    const alb = new HttpsAlb(this, 'PublicLoadBalancer', {
-      vpc,
-      certificateArns: [cdk.Fn.importValue(`${props.env.domainStackName}:ACMCertificateARN`)],
-      internetFacing: false,
-    })
-
-    const secretsHelper = (task: string, key: string) => {
-      const parameter = ssm.StringParameter.fromSecureStringParameterAttributes(this, `${task}${key}`, {
-        parameterName: `/all/${this.stackName}/${key}`,
-        version: 1, // This doesn't seem to matter in the context of ECS task definitions
-      })
-      return ecs.Secret.fromSsmParameter(parameter)
-    }
 
     // ECS Service
-    const cluster = new ecs.Cluster(this, 'FargateCluster', { vpc })
-
-    const appTask = new ecs.TaskDefinition(this, 'AppTaskDefinition', {
-      compatibility: ecs.Compatibility.FARGATE,
-      family: `${this.stackName}-Service`,
-      cpu: '2048',
-      memoryMiB: '4096',
-      networkMode: ecs.NetworkMode.AWS_VPC,
+    const appTask = new FargateTaskDefinition(this, 'AppTaskDefinition', {
+      cpu: 2048,
+      memoryLimitMiB: 4096,
     })
-
-    const logs = new LogGroup(this, 'SharedLogGroup', { retention: RetentionDays.TWO_WEEKS })
-
+    appTask.addVolume({
+      name: railsEfsVolumeName,
+      efsVolumeConfiguration: {
+        fileSystemId: fileSystem.fileSystemId,
+      },
+    })
     const logging = ecs.AwsLogDriver.awsLogs({
-      logGroup: logs,
+      logGroup: props.foundationStack.logs,
       streamPrefix: `${this.stackName}-Task`,
     })
 
@@ -86,33 +54,102 @@ export class HoneypotStack extends cdk.Stack {
       file: 'docker/Dockerfile',
     })
 
-    const container = appTask.addContainer('ruby24', {
+    const container = appTask.addContainer('railsContainer', {
       image: containerImage,
       command: ['bash', '/usr/bin/docker-entrypoint.sh'],
       essential: true,
       logging,
       secrets: {
-        SECRET_KEY_BASE: secretsHelper('HoneypotService', 'secret_key_base'),
+        SECRET_KEY_BASE: ECSSecretsHelper.fromSSM(this, 'HoneypotService', 'secret_key_base'),
       },
       environment: {
-        RAILS_RUN_ENV: 'production',
+        RAILS_ENV: 'production',
+        RAILS_LOG_TO_STDOUT: 'true',
       },
-
     })
     container.addPortMappings({
       containerPort: 3019,
     })
+    // Mount efs in the directory that rails is going to put it's generated images
+    container.addMountPoints({
+      readOnly: false,
+      sourceVolume: railsEfsVolumeName,
+      containerPath: '/honeypot/public/images',
+    })
+
+
+    const iipImage = AssetHelpers.containerFromDockerfile(this, 'IIPImageAsset', {
+      directory: props.appDirectory,
+      file: 'docker/Dockerfile.iip',
+    })
+    const iipContainer = appTask.addContainer('iipContainer', {
+      image: iipImage,
+      essential: true,
+      logging,
+      environment: {
+        VERBOSITY: '5',
+        LOGFILE: '/dev/stdout',
+        MAX_IMAGE_CACHE_SIZE: '10',
+        JPEG_QUALITY: '50',
+        MAX_CVT: '3000',
+        MEMCACHED_SERVERS: 'localhost',
+        FILESYSTEM_PREFIX: '/mnt/efs', // Relies on the request uri having /images and that there's a subdir /mnt/efs/images
+        CORS: '*',
+      },
+    })
+    // Get rendered (static) images from EFS
+    iipContainer.addMountPoints({
+      readOnly: true,
+      sourceVolume: railsEfsVolumeName,
+      containerPath: '/mnt/efs/images',
+    })
+
+    const nginxImage = AssetHelpers.containerFromDockerfile(this, 'NginxImageAsset', {
+      directory: props.appDirectory,
+      file: 'docker/Dockerfile.nginx',
+    })
+    const nginxContainer = appTask.addContainer('nginxContainer', {
+      image: nginxImage,
+      essential: true,
+      command: ['bash', 'project_root/nginx_entry.sh'],
+      logging,
+      environment: {
+        RAILS_HOST: '127.0.0.1',
+        RAILS_PORT: '3019',
+        RAILS_STATIC_DIR: '/honeypot/public', // We're going to mount this from the rails container to get static assets
+        IIP_HOST: '127.0.0.1',
+        IIP_PORT: '9000',
+      },
+    })
+    nginxContainer.addPortMappings({
+      containerPort: 80,
+    })
+    // Get static assets from the Rails container
+    nginxContainer.addVolumesFrom({
+      readOnly: true,
+      sourceContainer: 'railsContainer',
+    })
+    // Get rendered (static) images from EFS
+    nginxContainer.addMountPoints({
+      readOnly: true,
+      sourceVolume: railsEfsVolumeName,
+      containerPath: '/mnt/efs/images', // Mount the efs to the images dir so that requests to /images/* get served from the generated images
+    })
 
     // Define default container for the task before adding the service to the targetGroup,
     // otherwise CDK will try to create SecurityGroups for all ports on all containers
-    appTask.defaultContainer = container
+    appTask.defaultContainer = nginxContainer
 
     const appService = new ecs.FargateService(this, 'AppService', {
+      platformVersion: FargatePlatformVersion.VERSION1_4,
       taskDefinition: appTask,
-      cluster,
+      cluster: props.foundationStack.cluster,
       vpcSubnets: { subnetType: SubnetType.PRIVATE },
       desiredCount: 1,
     })
+
+    appService.connections.allowFrom(fileSystem, Port.tcp(2049))
+    appService.connections.allowTo(fileSystem, Port.tcp(2049))
 
     const targetGroup = new elbv2.ApplicationTargetGroup(this, 'TargetGroup', {
       healthCheck: {
@@ -122,29 +159,30 @@ export class HoneypotStack extends cdk.Stack {
         timeout: cdk.Duration.seconds(10),
         healthyThresholdCount: 2,
         unhealthyThresholdCount: 10,
-        port: '3019',
+        port: '80',
       },
       deregistrationDelay: cdk.Duration.seconds(60),
       targetType: elbv2.TargetType.IP,
-      port: 3019,
+      port: 80,
       protocol: elbv2.ApplicationProtocol.HTTP,
-      vpc,
+      vpc: props.foundationStack.vpc,
       targets: [appService],
     })
 
     const domainNameImport = cdk.Fn.importValue(`${props.env.domainStackName}:DomainName`)
+    this.hostname = `${props.hostnamePrefix}.${domainNameImport}`
     const elbv2Applistener = new elbv2.ApplicationListenerRule(this, 'ECSServiceRule2', {
       targetGroups: [targetGroup],
       pathPattern: '*',
-      hostHeader: `${props.hostnamePrefix}.${domainNameImport}`,
-      listener: alb.defaultListener,
-      priority: 1,
+      hostHeader: this.hostname,
+      listener: props.foundationStack.publicLoadBalancer.defaultListener,
+      priority: 2,
     })
 
     if (props.env.createDns) {
       const cnameRecord = new CnameRecord(this, 'ServiceCNAME', {
         recordName: props.hostnamePrefix,
-        domainName: alb.loadBalancerDnsName,
+        domainName: props.foundationStack.publicLoadBalancer.loadBalancerDnsName,
         zone: HostedZone.fromHostedZoneAttributes(this, 'ImportedHostedZone', {
           hostedZoneId: cdk.Fn.importValue(`${props.env.domainStackName}:Zone`),
           zoneName: domainNameImport,

--- a/src/namespaced-policy.ts
+++ b/src/namespaced-policy.ts
@@ -155,6 +155,7 @@ export class NamespacedPolicy {
         'route53:GetHostedZone',
         'route53:ChangeResourceRecordSets',
         'route53:GetChange',
+        'route53:ListResourceRecordSets',
       ],
       resources: [
         `arn:aws:route53:::hostedzone/${zone}`,

--- a/src/pipeline-foundation-stack.ts
+++ b/src/pipeline-foundation-stack.ts
@@ -1,0 +1,17 @@
+import { Construct, Stack, StackProps, RemovalPolicy } from "@aws-cdk/core"
+import { ArtifactBucket } from '@ndlib/ndlib-cdk'
+import { BucketEncryption } from "@aws-cdk/aws-s3"
+
+export class PipelineFoundationStack extends Stack {
+  /**
+   * Shared bucket for holding pipeline artifacts
+   */
+  public readonly artifactBucket: ArtifactBucket
+
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props)
+    this.artifactBucket = new ArtifactBucket(this, 'Bucket', {
+      encryption: BucketEncryption.KMS_MANAGED,
+    })
+  }
+}

--- a/src/pipeline-foundation-stack.ts
+++ b/src/pipeline-foundation-stack.ts
@@ -1,6 +1,6 @@
-import { Construct, Stack, StackProps, RemovalPolicy } from "@aws-cdk/core"
+import { Construct, Stack, StackProps, RemovalPolicy } from '@aws-cdk/core'
 import { ArtifactBucket } from '@ndlib/ndlib-cdk'
-import { BucketEncryption } from "@aws-cdk/aws-s3"
+import { BucketEncryption } from '@aws-cdk/aws-s3'
 
 export class PipelineFoundationStack extends Stack {
   /**
@@ -8,7 +8,7 @@ export class PipelineFoundationStack extends Stack {
    */
   public readonly artifactBucket: ArtifactBucket
 
-  constructor(scope: Construct, id: string, props?: StackProps) {
+  constructor (scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props)
     this.artifactBucket = new ArtifactBucket(this, 'Bucket', {
       encryption: BucketEncryption.KMS_MANAGED,

--- a/test/beehive-stack.test.ts
+++ b/test/beehive-stack.test.ts
@@ -21,12 +21,11 @@ describe('non-production infrastructure', () => {
       notificationReceivers: 'test@test.edu',
       alarmsEmail: 'test@test.edu',
     }
-    const foundationStack = new FoundationStack(app, 'MyFoundationStack', { env })
-    const beehiveContext = getContextByNamespace('beehive')
+    const foundationStack = new FoundationStack(app, 'MyFoundationStack', { env, honeycombHostnamePrefix: 'honeycomb-test' })
     return new BeehiveStack(app, 'MyTestStack', {
       foundationStack,
       env,
-      ...beehiveContext,
+      hostnamePrefix: 'MyTestStack-test',
     })
   }
 
@@ -34,7 +33,17 @@ describe('non-production infrastructure', () => {
     const newStack = stack()
     expectCDK(newStack).to(haveResource('AWS::S3::Bucket', {
       LoggingConfiguration: {
-        LogFilePrefix: 's3/MyTestStack-test',
+        LogFilePrefix: {
+          'Fn::Join': [
+            '',
+            [
+              's3/MyTestStack-test.',
+              {
+                'Fn::ImportValue': 'test-edu-domain:DomainName',
+              },
+            ],
+          ],
+        },
         DestinationBucketName: { 'Fn::ImportValue': 'MyFoundationStack:ExportsOutputReflogBucket1FE17E857A1D72F0' },
       },
     }))
@@ -126,7 +135,17 @@ describe('non-production infrastructure', () => {
         Logging: {
           Bucket: { 'Fn::ImportValue': 'MyFoundationStack:ExportsOutputFnGetAttlogBucket1FE17E85RegionalDomainName90114C32' },
           IncludeCookies: true,
-          Prefix: 'web/MyTestStack-test',
+          Prefix: {
+            'Fn::Join': [
+              '',
+              [
+                'web/MyTestStack-test.',
+                {
+                  'Fn::ImportValue': 'test-edu-domain:DomainName',
+                },
+              ],
+            ],
+          },
         },
       },
     }))
@@ -137,7 +156,17 @@ describe('non-production infrastructure', () => {
     expectCDK(newStack).to(haveResource('AWS::Route53::RecordSet', {
       Name: 'MyTestStack-test.test.edu.',
       Type: 'CNAME',
-      Comment: 'MyTestStack-test',
+      Comment: {
+        'Fn::Join': [
+          '',
+          [
+            'MyTestStack-test.',
+            {
+              'Fn::ImportValue': 'test-edu-domain:DomainName',
+            },
+          ],
+        ],
+      },
       HostedZoneId: { 'Fn::ImportValue': 'MyFoundationStack:ExportsOutputRefHostedZoneDB99F8662BBAE844' },
       ResourceRecords: [
         {
@@ -169,12 +198,12 @@ describe('production infrastructure', () => {
       notificationReceivers: 'test@test.edu',
       alarmsEmail: 'test@test.edu',
     }
-    const foundationStack = new FoundationStack(app, 'MyFoundationStack', { env })
+    const foundationStack = new FoundationStack(app, 'MyFoundationStack', { env, honeycombHostnamePrefix: 'honeycomb-test' })
     const beehiveContext = getContextByNamespace('beehive')
     return new BeehiveStack(app, 'MyTestStack', {
       foundationStack,
       env,
-      ...beehiveContext,
+      hostnamePrefix: 'MyTestStack',
     })
   }
 
@@ -182,7 +211,17 @@ describe('production infrastructure', () => {
     const newStack = stack()
     expectCDK(newStack).to(haveResource('AWS::S3::Bucket', {
       LoggingConfiguration: {
-        LogFilePrefix: 's3/MyTestStack',
+        LogFilePrefix: {
+          'Fn::Join': [
+            '',
+            [
+              's3/MyTestStack.',
+              {
+                'Fn::ImportValue': 'test-edu-domain:DomainName',
+              },
+            ],
+          ],
+        },
         DestinationBucketName: { 'Fn::ImportValue': 'MyFoundationStack:ExportsOutputReflogBucket1FE17E857A1D72F0' },
       },
     }))
@@ -216,7 +255,17 @@ describe('production infrastructure', () => {
         Logging: {
           Bucket: { 'Fn::ImportValue': 'MyFoundationStack:ExportsOutputFnGetAttlogBucket1FE17E85RegionalDomainName90114C32' },
           IncludeCookies: true,
-          Prefix: 'web/MyTestStack',
+          Prefix: {
+            'Fn::Join': [
+              '',
+              [
+                'web/MyTestStack.',
+                {
+                  'Fn::ImportValue': 'test-edu-domain:DomainName',
+                },
+              ],
+            ],
+          },
         },
       },
     }))
@@ -240,7 +289,7 @@ describe('do not create dns', () => {
       notificationReceivers: 'test@test.edu',
       alarmsEmail: 'test@test.edu',
     }
-    const foundationStack = new FoundationStack(app, 'MyFoundationStack', { env })
+    const foundationStack = new FoundationStack(app, 'MyFoundationStack', { env, honeycombHostnamePrefix: 'honeycomb-test' })
     const beehiveContext = getContextByNamespace('beehive')
     return new BeehiveStack(app, 'MyTestStack', {
       foundationStack,

--- a/test/buzz-stack.test.ts
+++ b/test/buzz-stack.test.ts
@@ -25,7 +25,7 @@ describe('non-production infrastructure', () => {
     }
     const hostnamePrefix = 'buzz-test'
     const buzzContext = getContextByNamespace('buzz')
-    const foundationStack = new FoundationStack(app, 'MyFoundationStack', { env })
+    const foundationStack = new FoundationStack(app, 'MyFoundationStack', { env, honeycombHostnamePrefix: 'honeycomb-test' })
     return new BuzzStack(app, 'MyBuzzStack', {
       env,
       foundationStack,
@@ -40,19 +40,6 @@ describe('non-production infrastructure', () => {
     const newStack = stack()
     expectCDK(newStack).to(haveResource('AWS::EC2::SecurityGroup', {
       VpcId: { 'Fn::ImportValue': 'test-network:VPCID' },
-    }))
-  })
-
-  test('puts proper ACM certificate on load balancer', () => {
-    const newStack = stack()
-    expectCDK(newStack).to(haveResource('AWS::ElasticLoadBalancingV2::Listener', {
-      Certificates: [
-        {
-          CertificateArn: {
-            'Fn::ImportValue': 'test-edu-domain:ACMCertificateARN',
-          },
-        },
-      ],
     }))
   })
 
@@ -112,7 +99,7 @@ describe('production infrastructure', () => {
       alarmsEmail: 'test@test.edu',
     }
     const buzzContext = getContextByNamespace('buzz')
-    const foundationStack = new FoundationStack(app, 'MyFoundationStack', { env })
+    const foundationStack = new FoundationStack(app, 'MyFoundationStack', { env, honeycombHostnamePrefix: 'honeycomb-test' })
     return new BuzzStack(app, 'MyBuzzStack', {
       env,
       name: 'prod',

--- a/test/honeycomb/honeycomb-stack.test.ts
+++ b/test/honeycomb/honeycomb-stack.test.ts
@@ -7,6 +7,9 @@ import { SolrConstruct } from '../../src/honeycomb/solr-construct'
 import { RabbitMqConstruct } from '../../src/honeycomb/rabbitmq-construct'
 import { RailsConstruct } from '../../src/honeycomb/rails-construct'
 import { CustomEnvironment } from '../../src/custom-environment'
+import { HoneypotStack } from '../../src/honeypot-stack'
+import { BuzzStack } from '../../src/buzz/buzz-stack'
+import { BeehiveStack } from '../../src/beehive-stack'
 
 jest.mock('../../src/honeycomb/solr-construct')
 const MockedSolrConstruct = mocked(SolrConstruct)
@@ -41,12 +44,34 @@ describe('HoneycombStack', () => {
       alarmsEmail: 'test@test.edu',
     }
     app = new cdk.App()
-    foundationStack = new FoundationStack(app, 'MyFoundationStack', { env })
+    foundationStack = new FoundationStack(app, 'MyFoundationStack', { env, honeycombHostnamePrefix: 'honeycomb-test' })
+
+    const honeypotStack = new HoneypotStack(app, 'MyHoneypotStack', {
+      foundationStack,
+      env,
+      hostnamePrefix: 'honeypot-test',
+      appDirectory: './test/fixtures',
+    })
+    const buzzStack = new BuzzStack(app, 'MyBuzzStack', {
+      foundationStack,
+      env,
+      hostnamePrefix: 'honeypot-test',
+      appDirectory: './test/fixtures',
+
+    })
+    const beehiveStack = new BeehiveStack(app, 'MyBeehiveStack', {
+      foundationStack,
+      env,
+      hostnamePrefix: 'honeypot-test',
+    })
     subject = new HoneycombStack(app, 'MyTestHoneycombStack', {
       env,
       appDirectory,
       foundationStack,
       hostnamePrefix,
+      honeypotStack,
+      buzzStack,
+      beehiveStack,
     })
   })
 

--- a/test/honeycomb/rabbitmq-construct.test.ts
+++ b/test/honeycomb/rabbitmq-construct.test.ts
@@ -27,7 +27,7 @@ describe('RabbitMqConstruct', () => {
     }
     const app = new cdk.App()
     const stack = new Stack(app, 'MyStack', { env })
-    const foundationStack = new FoundationStack(app, 'MyFoundationStack', { env })
+    const foundationStack = new FoundationStack(app, 'MyFoundationStack', { env, honeycombHostnamePrefix: 'honeycomb-test' })
     const appSecurityGroup = new SecurityGroup(stack, 'appSecurityGroup', {
       vpc: foundationStack.vpc,
       allowAllOutbound: true,

--- a/test/honeycomb/solr-construct.test.ts
+++ b/test/honeycomb/solr-construct.test.ts
@@ -24,7 +24,7 @@ describe('SolrConstruct', () => {
     }
     const app = new cdk.App()
     const stack = new Stack(app, 'MyStack', { env })
-    const foundationStack = new FoundationStack(app, 'MyFoundationStack', { env })
+    const foundationStack = new FoundationStack(app, 'MyFoundationStack', { env, honeycombHostnamePrefix: 'honeycomb-test' })
     const fileSystem = new FileSystem(stack, 'MyFileSystem', {
       vpc: foundationStack.vpc,
       lifecyclePolicy: LifecyclePolicy.AFTER_30_DAYS,

--- a/test/honeypot-stack.test.ts
+++ b/test/honeypot-stack.test.ts
@@ -21,7 +21,7 @@ describe('Production stack infrastructure', () => {
       notificationReceivers: 'test@test.edu',
       alarmsEmail: 'test@test.edu',
     }
-    const foundationStack = new FoundationStack(app, 'MyFoundationStack', { env })
+    const foundationStack = new FoundationStack(app, 'MyFoundationStack', { env, honeycombHostnamePrefix: 'honeycomb-test' })
     const honeypotContext = getContextByNamespace('honeypot')
     return new HoneypotStack(app, 'MyTestStack', {
       foundationStack,
@@ -54,7 +54,7 @@ describe('Dev stack infrastructure', () => {
       notificationReceivers: 'test@test.edu',
       alarmsEmail: 'test@test.edu',
     }
-    const foundationStack = new FoundationStack(app, 'MyFoundationStack', { env })
+    const foundationStack = new FoundationStack(app, 'MyFoundationStack', { env, honeycombHostnamePrefix: 'honeycomb-test' })
     const honeypotContext = getContextByNamespace('honeypot')
     return new HoneypotStack(app, 'MyTestStack', {
       foundationStack,


### PR DESCRIPTION
This is primarily to better integrate the stacks with each other, but
also includes a lot of changes to get the services fully functioning.
Changes:
- Changed all stacks to that require DB access to read the DB Security
Group from the foundation stack to minimize the number of SSM params we
have to maintain
- DRY'd up the secrets usage into a ECSSecretsHelper class
- Added Pipeline foundation for shared artifact buckets to keep bucket
counts down
- Added the media bucket to Foundation. This bucket is where Honeycomb
tells clients to put video and audio files (via a signed s3 url), and
where Buzz will point Wowza to for reads of those files
- Changed service stacks to use the shared ALB, Log groups, VPC, and ECS
Cluster shared by the Foundation stack
- Fixed Buzz pipeline usage of foundation stacks and added a smoke tests
against prod
- Fixed hostname overrides in Beehive
- Added Nginx and IIP tasks to Honeypot. It will first try to serve out
the static image requests via Nginx, then it will forward requests for
pyramid tiffs to the upstream Iip service, then all other requests to
the upstream Rails service.