### PR TITLE
Add Honeycomb Pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ aws ssm put-parameter --region us-east-1 --type 'String' --name "/all/${namespac
 
 aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-honeypot/secret_key_base" --description "Secret key base for verifying signed cookies" --value '<value>'
 
-aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-buzz/rails-secret-key-base" --description "Buzz rails secret key base" --value '<value>'
+aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-buzz/secrets/secret_key_base" --description "Buzz rails secret key base" --value '<value>'
 aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-buzz/database/database" --description "Buzz database name" --value '<value>'
 aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-buzz/database/host" --description "Buzz database hostname" --value '<value>'
 aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-buzz/database/port" --description "Buzz database port" --value '<value>'
@@ -49,11 +49,12 @@ aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${na
 aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-buzz/database/password" --description "Buzz database password" --value '<value>'
 aws ssm put-parameter --region us-east-1 --type 'String'       --name "/all/${namespace}-buzz/rails-env" --description "Buzz rails environment" --value '<value>'
 
-aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-honeycomb/rails-secret-key-base" --description "Honeycomb rails secret key base" --value '<value>'
+aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-honeycomb/secrets/secret_key_base" --description "Honeycomb rails secret key base" --value '<value>'
 aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-honeycomb/database/database" --description "Honeycomb database name" --value '<value>'
 aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-honeycomb/database/host" --description "Honeycomb database hostname" --value '<value>'
 aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-honeycomb/database/username" --description "Honeycomb database username" --value '<value>'
 aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-honeycomb/database/password" --description "Honeycomb database password" --value '<value>'
+aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-honeycomb/database/port" --description "Honeycomb database port" --value '<value>'
 aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-honeycomb/secrets/okta/client_id" --description "Honeycomb Okta client id" --value '<value>'
 aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-honeycomb/secrets/okta/client_secret" --description "Honeycomb Okta client secret" --value '<value>'
 aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-honeycomb/secrets/okta/logout_url" --description "Honeycomb Okta logout url" --value '<value>'

--- a/bin/pipelines.ts
+++ b/bin/pipelines.ts
@@ -2,10 +2,9 @@ import { App } from '@aws-cdk/core'
 import { CustomEnvironment } from '../src/custom-environment'
 import { Stacks } from '../src/types'
 import { getContextByNamespace } from '../src/context-helpers'
-import { FoundationStack } from '../src/foundation-stack'
-import { BuzzStack } from '../src/buzz/buzz-stack'
 import { BuzzPipelineStack } from '../src/buzz/buzz-pipeline'
 import { PipelineFoundationStack } from '../src/pipeline-foundation-stack'
+import { HoneycombPipelineStack } from '../src/honeycomb/honeycomb-pipeline'
 
 export const instantiateStacks = (app: App, namespace: string, env: CustomEnvironment, testStacks: Stacks, prodStacks: Stacks): Stacks => {
   const infraRepoName = app.node.tryGetContext('infraRepoName')
@@ -35,5 +34,11 @@ export const instantiateStacks = (app: App, namespace: string, env: CustomEnviro
     ...commonProps,
     ...buzzContext,
   })
-  return { buzzPipelineStack }
+
+  const honeycombContext = getContextByNamespace('honeycomb')
+  const honeycombPipelineStack = new HoneycombPipelineStack(app, `${namespace}-honeycomb-pipeline`, {
+    ...commonProps,
+    ...honeycombContext,
+  })
+  return { buzzPipelineStack, honeycombPipelineStack }
 }

--- a/src/buzz/buzz-stack.ts
+++ b/src/buzz/buzz-stack.ts
@@ -1,7 +1,7 @@
 import * as cdk from '@aws-cdk/core'
 import {
   AwsLogDriver,
-  Cluster,
+  FargatePlatformVersion,
   FargateService,
   FargateTaskDefinition,
 } from '@aws-cdk/aws-ecs'
@@ -71,12 +71,12 @@ export class BuzzStack extends cdk.Stack {
       },
       secrets: {
         RAILS_ENV: ECSSecretsHelper.fromSSM(this, 'RailsService', 'rails-env'),
-        RDS_PORT: ECSSecretsHelper.fromSSM(this, 'RailsService', 'database/port'),
-        RDS_USERNAME: ECSSecretsHelper.fromSSM(this, 'RailsService', 'database/username'),
-        RDS_PASSWORD: ECSSecretsHelper.fromSSM(this, 'RailsService', 'database/password'),
-        RDS_DB_NAME: ECSSecretsHelper.fromSSM(this, 'RailsService', 'database/database'),
-        RDS_HOSTNAME: ECSSecretsHelper.fromSSM(this, 'RailsService', 'database/host'),
-        RAILS_SECRET_KEY_BASE: ECSSecretsHelper.fromSSM(this, 'RailsService', 'rails-secret-key-base'),
+        DB_PORT: ECSSecretsHelper.fromSSM(this, 'RailsService', 'database/port'),
+        DB_USERNAME: ECSSecretsHelper.fromSSM(this, 'RailsService', 'database/username'),
+        DB_PASSWORD: ECSSecretsHelper.fromSSM(this, 'RailsService', 'database/password'),
+        DB_NAME: ECSSecretsHelper.fromSSM(this, 'RailsService', 'database/database'),
+        DB_HOSTNAME: ECSSecretsHelper.fromSSM(this, 'RailsService', 'database/host'),
+        RAILS_SECRET_KEY_BASE: ECSSecretsHelper.fromSSM(this, 'RailsService', 'secrets/secret_key_base'),
       },
     })
     rails.addPortMappings({
@@ -85,6 +85,7 @@ export class BuzzStack extends cdk.Stack {
 
     appTaskDefinition.defaultContainer = rails
     const appService = new FargateService(this, 'AppService', {
+      platformVersion: FargatePlatformVersion.VERSION1_4,
       taskDefinition: appTaskDefinition,
       cluster: props.foundationStack.cluster,
       vpcSubnets: { subnetType: SubnetType.PRIVATE },

--- a/src/cdk-pipeline-deploy.ts
+++ b/src/cdk-pipeline-deploy.ts
@@ -138,6 +138,13 @@ export class CDKPipelineDeploy extends Construct {
       ...props,
     })
 
+    this.project.addToRolePolicy(new PolicyStatement({
+      actions: ['ssm:GetParameters'],
+      resources: [
+        Fn.sub('arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/esu/dockerhub/token'),
+        Fn.sub('arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/esu/dockerhub/username')],
+    }))
+
     // CDK will try to read logs when generating output for failed events
     this.project.addToRolePolicy(new PolicyStatement({
       actions: ['logs:DescribeLogGroups'],
@@ -166,7 +173,6 @@ export class CDKPipelineDeploy extends Construct {
       resources: [Fn.sub('arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/CDKToolkit/*')],
     }))
     this.project.addToRolePolicy(new PolicyStatement({
-      // TODO: Is there a way to get the bucket name?
       actions: [
         's3:ListBucket',
         's3:GetObject',

--- a/src/honeycomb/rails-construct.ts
+++ b/src/honeycomb/rails-construct.ts
@@ -138,10 +138,10 @@ export class RailsConstruct extends Construct {
       AWS_PROFILE: '', // Need to blank this out so that it doesn't try to read shared credentials from files
     }
     const railsSecrets = {
-      DB_PASSWORD: ECSSecretsHelper.fromSSM(this, 'RailsService', 'rds/password'),
-      DB_HOST: ECSSecretsHelper.fromSSM(this, 'RailsService', 'rds/host'),
-      DB_USERNAME: ECSSecretsHelper.fromSSM(this, 'RailsService', 'rds/username'),
-      DB_NAME: ECSSecretsHelper.fromSSM(this, 'RaisService', 'rds/database'),
+      DB_PASSWORD: ECSSecretsHelper.fromSSM(this, 'RailsService', 'database/password'),
+      DB_HOSTNAME: ECSSecretsHelper.fromSSM(this, 'RailsService', 'database/host'),
+      DB_USERNAME: ECSSecretsHelper.fromSSM(this, 'RailsService', 'database/username'),
+      DB_NAME: ECSSecretsHelper.fromSSM(this, 'RaisService', 'database/database'),
       OKTA_CLIENT_ID: ECSSecretsHelper.fromSSM(this, 'RailsService', 'secrets/okta/client_id'),
       OKTA_CLIENT_SECRET: ECSSecretsHelper.fromSSM(this, 'RailsService', 'secrets/okta/client_secret'),
       OKTA_LOGOUT_URL: ECSSecretsHelper.fromSSM(this, 'RailsService', 'secrets/okta/logout_url'),


### PR DESCRIPTION
This is primarily to add a deployment pipeline for Honeycomb, but required
making some changes to other thing for consistency. Changes:
- Changed buzz pipeline to use the namespace when mapping ssm parameters
to better adhere to separation of stacks in dev
- Moved handling of permissions for the migration project into the migration
project since it should be able to handle this itself
- There were some differences between buzz and honeycomb in the env keys
and ssm paths for reading database properties. Made some changes to both
to be more consistent
- Updated Buzz to use the latest Fargate platform. Likely doesn't need it
but did so for consistency and to make for less maintenance in the future
when this becomes the default
- Expanded migration project to allow passing additional env and commands
that need to run before migration. Needed this in order to recreate some
of the configuration that happens inside of the Honeycomb container when
it's built.
- Did a bit of refactoring of the namespaced policies to pare down some
policies, and make others a bit easier to maintain