### PR TITLE
Fix host configuration

### DIFF
--- a/bin/pipelines.ts
+++ b/bin/pipelines.ts
@@ -36,16 +36,19 @@ export const instantiateStacks = (app: App, namespace: string, env: CustomEnviro
     ...buzzContext,
   })
 
-  const honeycombContext = getContextByNamespace('honeycomb')
-  const honeycombPipelineStack = new HoneycombPipelineStack(app, `${namespace}-honeycomb-pipeline`, {
-    ...commonProps,
-    ...honeycombContext,
-  })
-
   const honeypotContext = getContextByNamespace('honeypot')
   const honeypotPipelineStack = new HoneypotPipelineStack(app, `${namespace}-honeypot-pipeline`, {
     ...commonProps,
     ...honeypotContext,
+  })
+
+  const honeycombContext = getContextByNamespace('honeycomb')
+  const honeycombPipelineStack = new HoneycombPipelineStack(app, `${namespace}-honeycomb-pipeline`, {
+    ...commonProps,
+    ...honeycombContext,
+    honeypotPipelineStack,
+    buzzPipelineStack,
+    // beehivePipelineStack,
   })
 
   return { buzzPipelineStack, honeycombPipelineStack, honeypotPipelineStack }

--- a/src/buzz/buzz-pipeline.ts
+++ b/src/buzz/buzz-pipeline.ts
@@ -28,6 +28,9 @@ export interface CDPipelineStackProps extends cdk.StackProps {
 }
 
 export class BuzzPipelineStack extends Stack {
+  readonly testHostnamePrefix: string
+  readonly prodHostnamePrefix: string
+
   constructor (scope: cdk.Construct, id: string, props: CDPipelineStackProps) {
     super(scope, id, props)
 
@@ -111,12 +114,12 @@ export class BuzzPipelineStack extends Stack {
     const createDns = props.env.createDns ? 'true' : 'false'
 
     const testNamespace = `${props.namespace}-test`
-    const testHostnamePrefix = `${props.hostnamePrefix}-test`
-    const testHostname = `${testHostnamePrefix}.${props.testFoundationStack.hostedZone.zoneName}`
+    this.testHostnamePrefix = `${props.hostnamePrefix}-test`
+    const testHostname = `${this.testHostnamePrefix}.${props.testFoundationStack.hostedZone.zoneName}`
 
     const prodNamespace = `${props.namespace}-prod`
-    const prodHostnamePrefix = props.hostnamePrefix
-    const prodHostname = `${prodHostnamePrefix}.${props.prodFoundationStack.hostedZone.zoneName}`
+    this.prodHostnamePrefix = props.hostnamePrefix
+    const prodHostname = `${this.prodHostnamePrefix}.${props.prodFoundationStack.hostedZone.zoneName}`
 
     const pipeline = new RailsPipeline(this, 'DeploymentPipeline', {
       env: props.env,
@@ -152,7 +155,7 @@ export class BuzzPipelineStack extends Stack {
           networkStack: props.env.networkStackName,
           domainStack: props.env.domainStackName,
           createDns,
-          'buzz:hostnamePrefix': testHostnamePrefix,
+          'buzz:hostnamePrefix': this.testHostnamePrefix,
           'buzz:appDirectory': '$CODEBUILD_SRC_DIR_AppCode',
         },
       },
@@ -168,7 +171,7 @@ export class BuzzPipelineStack extends Stack {
           networkStack: props.env.networkStackName,
           domainStack: props.env.domainStackName,
           createDns,
-          'buzz:hostnamePrefix': prodHostnamePrefix,
+          'buzz:hostnamePrefix': this.prodHostnamePrefix,
           'buzz:appDirectory': '$CODEBUILD_SRC_DIR_AppCode',
         },
       },

--- a/src/honeycomb/honeycomb-pipeline.ts
+++ b/src/honeycomb/honeycomb-pipeline.ts
@@ -6,6 +6,8 @@ import { CustomEnvironment } from '../custom-environment'
 import { FoundationStack } from '../foundation-stack'
 import { PipelineFoundationStack } from '../pipeline-foundation-stack'
 import { RailsPipelineContainerProps, RailsPipeline, RailsPipelineStageProps } from '../pipeline-constructs/rails-pipeline'
+import { HoneypotPipelineStack } from '../honeypot/honeypot-pipeline'
+import { BuzzPipelineStack } from '../buzz/buzz-pipeline'
 
 export interface CDPipelineStackProps extends StackProps {
   readonly env: CustomEnvironment;
@@ -24,6 +26,9 @@ export interface CDPipelineStackProps extends StackProps {
   readonly testFoundationStack: FoundationStack
   readonly prodFoundationStack: FoundationStack
   readonly hostnamePrefix: string
+  readonly honeypotPipelineStack: HoneypotPipelineStack
+  readonly buzzPipelineStack: BuzzPipelineStack
+  // readonly beehivePipelineStack: BeehivePipelineStack
 }
 
 export class HoneycombPipelineStack extends Stack {
@@ -162,6 +167,9 @@ export class HoneycombPipelineStack extends Stack {
           createDns,
           'honeycomb:hostnamePrefix': testHostnamePrefix,
           'honeycomb:appDirectory': '$CODEBUILD_SRC_DIR_AppCode',
+          'honeypot:hostnamePrefix': props.honeypotPipelineStack.testHostnamePrefix,
+          'buzz:hostnamePrefix': props.buzzPipelineStack.testHostnamePrefix,
+          'beehive:hostnamePrefix': 'beehive-test', // TODO: Get this from the beehive pipeline once implemented
         },
       },
       prodStage: {
@@ -178,6 +186,9 @@ export class HoneycombPipelineStack extends Stack {
           createDns,
           'honeycomb:hostnamePrefix': prodHostnamePrefix,
           'honeycomb:appDirectory': '$CODEBUILD_SRC_DIR_AppCode',
+          'honeypot:hostnamePrefix': props.honeypotPipelineStack.prodHostnamePrefix,
+          'buzz:hostnamePrefix': props.buzzPipelineStack.prodHostnamePrefix,
+          'beehive:hostnamePrefix': 'beehive', // TODO: Get this from the beehive pipeline once implemented
         },
       },
     })

--- a/src/honeypot/honeypot-pipeline.ts
+++ b/src/honeypot/honeypot-pipeline.ts
@@ -28,6 +28,9 @@ export interface CDPipelineStackProps extends cdk.StackProps {
 }
 
 export class HoneypotPipelineStack extends Stack {
+  readonly testHostnamePrefix: string
+  readonly prodHostnamePrefix: string
+
   constructor (scope: cdk.Construct, id: string, props: CDPipelineStackProps) {
     super(scope, id, props)
 
@@ -113,12 +116,12 @@ export class HoneypotPipelineStack extends Stack {
     const createDns = props.env.createDns ? 'true' : 'false'
 
     const testNamespace = `${props.namespace}-test`
-    const testHostnamePrefix = `${props.hostnamePrefix}-test`
-    const testHostname = `${testHostnamePrefix}.${props.testFoundationStack.hostedZone.zoneName}`
+    this.testHostnamePrefix = `${props.hostnamePrefix}-test`
+    const testHostname = `${this.testHostnamePrefix}.${props.testFoundationStack.hostedZone.zoneName}`
 
     const prodNamespace = `${props.namespace}-prod`
-    const prodHostnamePrefix = props.hostnamePrefix
-    const prodHostname = `${prodHostnamePrefix}.${props.prodFoundationStack.hostedZone.zoneName}`
+    this.prodHostnamePrefix = props.hostnamePrefix
+    const prodHostname = `${this.prodHostnamePrefix}.${props.prodFoundationStack.hostedZone.zoneName}`
 
     const pipeline = new RailsPipeline(this, 'DeploymentPipeline', {
       env: props.env,
@@ -154,7 +157,7 @@ export class HoneypotPipelineStack extends Stack {
           networkStack: props.env.networkStackName,
           domainStack: props.env.domainStackName,
           createDns,
-          'honeypot:hostnamePrefix': testHostnamePrefix,
+          'honeypot:hostnamePrefix': this.testHostnamePrefix,
           'honeypot:appDirectory': '$CODEBUILD_SRC_DIR_AppCode',
         },
       },
@@ -170,7 +173,7 @@ export class HoneypotPipelineStack extends Stack {
           networkStack: props.env.networkStackName,
           domainStack: props.env.domainStackName,
           createDns,
-          'honeypot:hostnamePrefix': prodHostnamePrefix,
+          'honeypot:hostnamePrefix': this.prodHostnamePrefix,
           'honeypot:appDirectory': '$CODEBUILD_SRC_DIR_AppCode',
         },
       },


### PR DESCRIPTION
There was a problem when deploying via pipelines that was preventing test
services from talking to other test services. Ex: honeycomb-test was
pushing images to honeypot-prod instead of honeypot-test. Changed honeycomb
to add context overrides for the hostname prefixes. It will get these values
from the other pipelines, since that information is really only known by
the other pipelines. It may make sense at some point to make a stage type
that, when given to a stack, allows the service stack to determine the
full hostname. We could then do away with requiring passing this info
around via pipelines, but that's a slightly bigger change then I want to
look at for this.