### PR TITLE
Fix beehive hostname and bump rails resources

### DIFF
--- a/src/honeycomb/honeycomb-pipeline.ts
+++ b/src/honeycomb/honeycomb-pipeline.ts
@@ -169,7 +169,7 @@ export class HoneycombPipelineStack extends Stack {
           'honeycomb:appDirectory': '$CODEBUILD_SRC_DIR_AppCode',
           'honeypot:hostnamePrefix': props.honeypotPipelineStack.testHostnamePrefix,
           'buzz:hostnamePrefix': props.buzzPipelineStack.testHostnamePrefix,
-          'beehive:hostnamePrefix': 'beehive-test', // TODO: Get this from the beehive pipeline once implemented
+          'beehive:hostnamePrefix': 'collections-test', // TODO: Get this from the beehive pipeline once implemented
         },
       },
       prodStage: {
@@ -188,7 +188,7 @@ export class HoneycombPipelineStack extends Stack {
           'honeycomb:appDirectory': '$CODEBUILD_SRC_DIR_AppCode',
           'honeypot:hostnamePrefix': props.honeypotPipelineStack.prodHostnamePrefix,
           'buzz:hostnamePrefix': props.buzzPipelineStack.prodHostnamePrefix,
-          'beehive:hostnamePrefix': 'beehive', // TODO: Get this from the beehive pipeline once implemented
+          'beehive:hostnamePrefix': 'collections', // TODO: Get this from the beehive pipeline once implemented
         },
       },
     })

--- a/src/honeycomb/rails-construct.ts
+++ b/src/honeycomb/rails-construct.ts
@@ -165,6 +165,7 @@ export class RailsConstruct extends Construct {
     // Create a task definition with more resources that can be run in an adhoc, short
     // lived manner. Also sets log level higher to get additional output
     const rakeTaskDefinition = new FargateTaskDefinition(this, 'RakeTaskDefinition', {
+      cpu: 1024,
       memoryLimitMiB: 2048,
     })
 
@@ -217,7 +218,10 @@ export class RailsConstruct extends Construct {
     rakeContainer.addMountPoints(systemMountPoint)
 
     // Rails service task
-    const appTaskDefinition = new FargateTaskDefinition(this, 'RailsTaskDefinition')
+    const appTaskDefinition = new FargateTaskDefinition(this, 'RailsTaskDefinition', {
+      cpu: 512,
+      memoryLimitMiB: 1024,
+    })
     appTaskDefinition.addVolume(railsVolume)
     const railsContainer = appTaskDefinition.addContainer('railsContainer', {
       image: railsImage,


### PR DESCRIPTION
Fixed an incorrect hostname for beehive. Bump resources on the rake task
by default to make reindexing the site faster (this can still be
overridden when creating a task). Bumped the resources for the rails
service. The site seemed a bit more sluggish than the live site for
the larger collections. This puts it a bit closer to the current performance.