### PR TITLE
Add Hesburgh API secrets to Honeycomb

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${na
 aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-honeycomb/secrets/google/client_secret" --description "Honeycomb Google client secret" --value '<value>'
 aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-honeycomb/secrets/google/developer_key" --description "Honeycomb Google developer key" --value '<value>'
 aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-honeycomb/secrets/google/app_id" --description "Honeycomb Google app id" --value '<value>'
+aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-honeycomb/secrets/hesburgh_api/token" --description "Hesburgh API token" --value '<value'
+aws ssm put-parameter --region us-east-1 --type 'SecureString' --name "/all/${namespace}-honeycomb/secrets/hesburgh_api/url" --description "Hesburgh API URL" --value '<value>'
 ```
 
 ## How to deploy

--- a/src/honeycomb/rails-construct.ts
+++ b/src/honeycomb/rails-construct.ts
@@ -160,6 +160,8 @@ export class RailsConstruct extends Construct {
       GOOGLE_APP_ID: ECSSecretsHelper.fromSSM(this, 'RailsService', 'secrets/google/app_id'),
       RABBIT_LOGIN: Secret.fromSecretsManager(props.rabbitMq.secret, 'login'),
       RABBIT_PASSWORD: Secret.fromSecretsManager(props.rabbitMq.secret, 'password'),
+      HAPI_TOKEN: ECSSecretsHelper.fromSSM(this, 'RailsService', 'secrets/hesburgh_api/token'),
+      HAPI_URL: ECSSecretsHelper.fromSSM(this, 'RailsService', 'secrets/hesburgh_api/url'),
     }
 
     // Create a task definition with more resources that can be run in an adhoc, short


### PR DESCRIPTION
Change Honeycomb to pull the Hesburgh API endpoint url and token from
ssm and inject it into the env for the ECS task.